### PR TITLE
Fix dashboard user data loading

### DIFF
--- a/php/database.php
+++ b/php/database.php
@@ -26,8 +26,8 @@ class DatabaseConfig {
 
             $pdo = new PDO($dsn, self::$username, self::$password, $options);
 
-            // Stampa le tabelle presenti nel database
-            self::printDatabaseTables($pdo);
+            // self::printDatabaseTables($pdo);
+            // Disabilitato per evitare output HTML che compromette le API
 
             return $pdo;
         } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- disable debug output in `DatabaseConfig` to allow JSON APIs to return valid responses

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bcbf668bc8321bd0da6fadb6c371d