### PR TITLE
Aggiornamento caricamento immagine profilo e overlay

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -915,6 +915,27 @@ input:checked + .toggle-slider:before {
   display: block;
 }
 
+/* Overlay di caricamento */
+.loading-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  color: var(--text-light);
+  font-size: 1.25rem;
+  font-weight: 600;
+  z-index: 999;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading-overlay.active {
+  display: flex;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
   .profile-container {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -13,6 +13,26 @@ class DashboardManager {
     }
 
     /**
+     * Mostra la schermata di caricamento
+     */
+    showLoading() {
+        const loader = document.getElementById('loadingOverlay');
+        if (loader) {
+            loader.classList.add('active');
+        }
+    }
+
+    /**
+     * Nasconde la schermata di caricamento
+     */
+    hideLoading() {
+        const loader = document.getElementById('loadingOverlay');
+        if (loader) {
+            loader.classList.remove('active');
+        }
+    }
+
+    /**
      * Inizializzazione del dashboard
      */
     init() {
@@ -37,6 +57,17 @@ class DashboardManager {
         return Array.from(crypto.getRandomValues(new Uint8Array(32)))
             .map(b => b.toString(16).padStart(2, '0'))
             .join('');
+    }
+
+    /**
+     * Restituisce il percorso corretto per le immagini
+     */
+    formatImagePath(path) {
+        if (!path) return '';
+        if (/^(https?:\/\/|\.|\/)/.test(path)) {
+            return path;
+        }
+        return '../' + path;
     }
 
     /**
@@ -250,6 +281,7 @@ class DashboardManager {
      * Carica dati utente
      */
     async loadUserData() {
+        this.showLoading();
         try {
             const response = await fetch('../php/profile_api.php');
             const data = await response.json();
@@ -262,6 +294,8 @@ class DashboardManager {
         } catch (error) {
             console.error('Errore caricamento dati utente:', error);
             this.showNotification('Errore di connessione', 'error');
+        } finally {
+            this.hideLoading();
         }
     }
 
@@ -284,11 +318,11 @@ class DashboardManager {
         }
 
         if (userAvatar && userData.profile_photo) {
-            userAvatar.src = userData.profile_photo;
+            userAvatar.src = this.formatImagePath(userData.profile_photo);
         }
 
         if (profilePhoto && userData.profile_photo) {
-            profilePhoto.src = userData.profile_photo;
+            profilePhoto.src = this.formatImagePath(userData.profile_photo);
         }
 
         if (profileUsername) {
@@ -395,8 +429,9 @@ class DashboardManager {
                 // Aggiorna le immagini
                 const userAvatar = document.getElementById('userAvatar');
                 const profilePhoto = document.getElementById('profilePhoto');
-                if (userAvatar) userAvatar.src = result.photo_url + '?t=' + Date.now();
-                if (profilePhoto) profilePhoto.src = result.photo_url + '?t=' + Date.now();
+                const updatedPath = this.formatImagePath(result.photo_url) + '?t=' + Date.now();
+                if (userAvatar) userAvatar.src = updatedPath;
+                if (profilePhoto) profilePhoto.src = updatedPath;
             } else {
                 this.showNotification(result.message || 'Errore durante l\'upload', 'error');
             }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -387,6 +387,8 @@
 
   <!-- Overlay per mobile -->
   <div class="overlay" id="overlay"></div>
+  <!-- Overlay di caricamento -->
+  <div class="loading-overlay" id="loadingOverlay" role="status" aria-live="polite">Caricamento in corso...</div>
 
   <script src="../js/dashboard.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- aggiorna dashboard.js per mostrare un overlay di caricamento e per caricare la foto profilo dal database
- aggiunge stile e markup dell'overlay di caricamento
- sistema i percorsi delle immagini del profilo

## Testing
- `npm test` *(fallito: manca package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685bd3db6b188321b2464c775f81b486