### PR TITLE
Fix CSRF token for dashboard forms

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -35,8 +35,8 @@ class DashboardManager {
     /**
      * Inizializzazione del dashboard
      */
-    init() {
-        this.generateCSRFToken();
+    async init() {
+        await this.generateCSRFToken();
         this.setupEventListeners();
         this.setupSidebar();
         this.loadUserData();
@@ -49,7 +49,17 @@ class DashboardManager {
     /**
      * Genera token CSRF
      */
-    generateCSRFToken() {
+    async generateCSRFToken() {
+        try {
+            const response = await fetch('../php/csrf_token.php');
+            const data = await response.json();
+            if (data.csrf_token) {
+                this.csrfToken = data.csrf_token;
+                return;
+            }
+        } catch (error) {
+            console.error('Errore nel recupero del token CSRF:', error);
+        }
         this.csrfToken = this.generateRandomToken();
     }
 

--- a/php/csrf_token.php
+++ b/php/csrf_token.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Endpoint per fornire il token CSRF
+ */
+require_once 'database.php';
+
+// Avvia la sessione
+SessionManager::start();
+
+// Imposta header per JSON
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+echo json_encode(['csrf_token' => Utils::generateCSRFToken()]);
+


### PR DESCRIPTION
## Summary
- provide an API to retrieve the server CSRF token
- fetch the token when the dashboard loads

## Testing
- `php -l php/csrf_token.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685be67d58248321a1b1c956eeb6f833