### PR TITLE
Fix dashboard header and review editing

### DIFF
--- a/index.php
+++ b/index.php
@@ -60,7 +60,7 @@ if (!SessionManager::isLoggedIn()) {
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>
-                          <a href='static/dashboard.html'>Dashboard</a>";
+                          <a href='php/dashboard.php'>Dashboard</a>";
   if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
       $headerLoginHtml .= "\n                          <a href='php/gestione_recensioni.php'>Gestione recensioni</a>";
   }

--- a/js/gestione_recensioni.js
+++ b/js/gestione_recensioni.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const data = await res.json();
       if (data.success) {
         list.innerHTML = data.data.reviews.map(r => `
-          <div class="review-item" data-id="${r.id}">
+          <div class="review-item" data-id="${r.id}" data-product="${escapeHtml(r.product_name)}" data-rating="${r.rating}">
             <h3>${escapeHtml(r.title)}</h3>
             <p>${escapeHtml(r.content)}</p>
             <div class="review-actions">
@@ -105,8 +105,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     } else if (e.target.classList.contains('edit-btn')) {
       const item = e.target.closest('.review-item');
       form.title.value = item.querySelector('h3').textContent;
-      form.product.value = '';
-      form.rating.value = 5;
+      form.product.value = item.dataset.product || '';
+      form.rating.value = item.dataset.rating || 5;
       form.content.value = item.querySelector('p').textContent;
       form.dataset.editId = e.target.dataset.id;
       submitBtn.textContent = 'Aggiorna';

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -61,7 +61,7 @@ if (!SessionManager::isLoggedIn()) {
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>
-                          <a href='../static/dashboard.html'>Dashboard</a>";
+                          <a href='dashboard.php'>Dashboard</a>";
   if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
       $headerLoginHtml .= "\n                          <a href='gestione_recensioni.php'>Gestione recensioni</a>";
   }

--- a/php/contatti.php
+++ b/php/contatti.php
@@ -60,7 +60,7 @@ if (!SessionManager::isLoggedIn()) {
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>
-                          <a href='../static/dashboard.html'>Dashboard</a>";
+                          <a href='dashboard.php'>Dashboard</a>";
   if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
       $headerLoginHtml .= "\n                          <a href='gestione_recensioni.php'>Gestione recensioni</a>";
   }

--- a/php/dashboard.php
+++ b/php/dashboard.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Pagina di gestione delle recensioni (solo admin)
- *
- * Consente di pubblicare, modificare ed eliminare recensioni
+ * Pagina dashboard utente
  */
 
 require_once 'database.php';
@@ -10,15 +8,9 @@ require_once 'database.php';
 SessionManager::start();
 SessionManager::requireLogin();
 
-if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
-    http_response_code(403);
-    echo 'Accesso negato';
-    exit();
-}
-
 $header = file_get_contents("../static/header.html");
 $footer = file_get_contents("../static/footer.html");
-$DOM = file_get_contents("../static/gestione_recensioni.html");
+$DOM = file_get_contents("../static/dashboard.html");
 
 $DOM = str_replace("<!-- HEADER_PLACEHOLDER -->", $header, $DOM);
 $DOM = str_replace("<!-- FOOTER_PLACEHOLDER -->", $footer, $DOM);
@@ -34,13 +26,15 @@ $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>
-                          <a href='dashboard.php'>Dashboard</a>
-                          <a href='gestione_recensioni.php'>Gestione recensioni</a>
-                          <a href='logout.php'>Logout</a>
+                          <a href='dashboard.php'>Dashboard</a>";
+if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
+    $headerLoginHtml .= "\n                          <a href='gestione_recensioni.php'>Gestione recensioni</a>";
+}
+$headerLoginHtml .= "\n                          <a href='logout.php'>Logout</a>
                         </div>
                       </div>";
 
 $DOM = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $DOM);
 
 echo $DOM;
-?>
+

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -61,7 +61,7 @@ if (!SessionManager::isLoggedIn()) {
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>
-                          <a href='../static/dashboard.html'>Dashboard</a>";
+                          <a href='dashboard.php'>Dashboard</a>";
   if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
       $headerLoginHtml .= "\n                          <a href='gestione_recensioni.php'>Gestione recensioni</a>";
   }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -12,42 +12,7 @@
 <body>
   <a href="#main-content" class="skip-link">Salta al contenuto principale</a>
 
-  <!-- Header -->
-  <header class="header">
-    <nav class="navbar">
-      <div class="nav-container">
-        <a href="../index.php" class="logo-link" aria-label="Torna alla homepage di ReviewDiver">
-          <img src="../images/logo.png" alt="Logo ReviewDiver" class="logo">
-        </a>
-        <div class="hamburger-menu" aria-label="Menu di navigazione" role="button" tabindex="0">
-          <div class="bar"></div>
-          <div class="bar"></div>
-          <div class="bar"></div>
-        </div>
-        <div class="nav-links" role="menubar">
-          <li><a href="../index.php" class="nav-link-item">Home</a></li>
-          <li><a href="../php/recensioni.php" class="nav-link-item">Recensioni</a></li>
-          <li><a href="../php/classifiche.php" class="nav-link-item">Classifiche</a></li>
-          <li><a href="../php/contatti.php" class="nav-link-item">Contatti</a></li>
-        </div>
-      </div>
-        <div class="nav-right">
-          <div class="user-info">
-            <img src="../images/profileimage/image1.jpg" alt="Avatar utente" class="user-avatar" id="userAvatar">
-            <span class="user-name" id="userName"></span>
-          </div>
-
-          <button class="logout-btn" id="logoutBtn" aria-label="Esci dal tuo account">
-            <i aria-hidden="true" class="fas fa-sign-out-alt"></i>
-            <span>Logout</span>
-          </button>
-
-          <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Apri menu laterale">
-            <i aria-hidden="true" class="fas fa-bars"></i>
-          </button>
-        </div>
-    </nav>
-  </header>
+  <!-- HEADER_PLACEHOLDER -->
 
   <!-- Sidebar -->
   <aside class="sidebar" id="sidebar">
@@ -390,6 +355,8 @@
   <div class="overlay" id="overlay"></div>
   <!-- Overlay di caricamento -->
   <div class="loading-overlay" id="loadingOverlay" role="status" aria-live="polite">Caricamento in corso...</div>
+
+  <!-- FOOTER_PLACEHOLDER -->
 
   <script src="../js/dashboard.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add dynamic dashboard PHP page using common header and footer
- replace static dashboard header with placeholder
- link to new dashboard page from other pages
- keep rating/product when editing a review

## Testing
- `php -l php/dashboard.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685c2a437a8883219039ffabea45b210