### PR TITLE
Fix login icon overlap and add user avatar in header

### DIFF
--- a/css/auth-styles.css
+++ b/css/auth-styles.css
@@ -200,6 +200,7 @@ body {
   transform: translateY(-50%);
   width: 20px;
   height: 20px;
+  pointer-events: none;
   color: var(--color-text-secondary);
   transition: var(--transition);
   z-index: 1;

--- a/index.php
+++ b/index.php
@@ -51,12 +51,12 @@ if (!SessionManager::isLoggedIn()) {
   $contenutoLogin = "";
 
   // Menu utente per l'header
+  $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
+  $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
+
   $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         <div class='user-icon-bg'>
-                          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
-                            <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>
-                            <circle cx='12' cy='7' r='4'></circle>
-                          </svg>
+                          {$icon}
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -52,12 +52,12 @@ if (!SessionManager::isLoggedIn()) {
   $contenutoLogin = "";
 
   // Menu utente per l'header
+  $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
+  $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
+
   $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         <div class='user-icon-bg'>
-                          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
-                            <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>
-                            <circle cx='12' cy='7' r='4'></circle>
-                          </svg>
+                          {$icon}
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>

--- a/php/contatti.php
+++ b/php/contatti.php
@@ -51,12 +51,12 @@ if (!SessionManager::isLoggedIn()) {
   $contenutoLogin = "";
 
   // Menu utente per l'header
+  $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
+  $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
+
   $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         <div class='user-icon-bg'>
-                          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
-                            <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>
-                            <circle cx='12' cy='7' r='4'></circle>
-                          </svg>
+                          {$icon}
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>

--- a/php/dashboard.php
+++ b/php/dashboard.php
@@ -17,12 +17,11 @@ $DOM = str_replace("<!-- FOOTER_PLACEHOLDER -->", $footer, $DOM);
 
 $username = $_SESSION['username'];
 
+$profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
+$icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
 $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         <div class='user-icon-bg'>
-                          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
-                            <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>
-                            <circle cx='12' cy='7' r='4'></circle>
-                          </svg>
+                          {$icon}
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>

--- a/php/gestione_recensioni.php
+++ b/php/gestione_recensioni.php
@@ -25,12 +25,11 @@ $DOM = str_replace("<!-- FOOTER_PLACEHOLDER -->", $footer, $DOM);
 
 $username = $_SESSION['username'];
 
+$profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
+$icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
 $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         <div class='user-icon-bg'>
-                          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
-                            <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>
-                            <circle cx='12' cy='7' r='4'></circle>
-                          </svg>
+                          {$icon}
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>

--- a/php/login.php
+++ b/php/login.php
@@ -70,7 +70,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'email' => $user['email'],
                     'role' => $user['role'],
                     'nome' => $user['nome'],
-                    'cognome' => $user['cognome']
+                    'cognome' => $user['cognome'],
+                    'profile_photo' => $user['profile_photo']
                 ];
 
                 SessionManager::login($user['id'], $userData);
@@ -80,6 +81,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_SESSION['username'] = $user['username'];
                 $_SESSION['is_logged_in'] = true;
                 $_SESSION['role'] = $user['role'];
+                $_SESSION['profile_photo'] = $user['profile_photo'];
 
                 // Se l'utente ha selezionato "Ricordami", impostiamo un cookie
                 if ($remember) {

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -52,12 +52,12 @@ if (!SessionManager::isLoggedIn()) {
   $contenutoLogin = "";
 
   // Menu utente per l'header
+  $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
+  $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
+
   $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'>
                         <div class='user-icon-bg'>
-                          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
-                            <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>
-                            <circle cx='12' cy='7' r='4'></circle>
-                          </svg>
+                          {$icon}
                         </div>
                         <div class='login-text'>{$username}</div>
                         <div class='user-dropdown'>


### PR DESCRIPTION
## Summary
- adjust form icons to avoid overlap with placeholders
- store `profile_photo` in session during login
- display the user's profile photo in the header after login

## Testing
- `node --version`
- `php -l php/login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c3164b2508321b6a093385b502618