### PR TITLE
Fix sidebar close icon visibility

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -61,7 +61,7 @@ body {
 }
 
 .sidebar-close {
-  display: none;
+  display: block;
   background: none;
   border: none;
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- ensure `.sidebar-close` is visible on all screen sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c562e47e08321b6f0113757b81109