### PR TITLE
Fix minor login link quoting error

### DIFF
--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -34,7 +34,7 @@ if (!SessionManager::isLoggedIn()) {
   $contenutoLogin = "";
 
   // Link di login per l'header
-  $headerLoginHtml = "<a href=login_form.php' class='login-link' aria-label='Accedi al tuo account'>
+  $headerLoginHtml = "<a href='login_form.php' class='login-link' aria-label='Accedi al tuo account'>
                         <div class='user-icon-bg'>
                           <svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='userIcon'>
                             <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path>


### PR DESCRIPTION
## Summary
- fix malformed href attribute for login link in `php/recensioni.php`

## Testing
- `php -l php/recensioni.php`
- `find js -name '*.js' -print0 | xargs -0 -n1 node --check`

------
https://chatgpt.com/codex/tasks/task_b_685c70880954832193878db20f2a6e88