### PR TITLE
Make loading overlay opaque

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -936,7 +936,8 @@ input:checked + .toggle-slider::before {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgb(0 0 0 / 70%);
+  /* Overlay completamente opaco per nascondere i contenuti sottostanti */
+  background: rgb(0 0 0);
   color: var(--text-light);
   font-size: 1.25rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- make the loading overlay background fully opaque so that sidebar and main content are hidden during loading

## Testing
- `grep -n "loading-overlay" -n css/dashboard.css`

------
https://chatgpt.com/codex/tasks/task_b_685d22f637988321a3556be088ea5d1d