### PR TITLE
Improve dashboard loading flow

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -30,6 +30,8 @@ body {
   transition: var(--transition);
 }
 
+.hidden { display: none !important; }
+
 
 /* Sidebar */
 .sidebar {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -31,6 +31,11 @@ class DashboardManager {
             loader.classList.remove('active');
         }
     }
+    showPage() {
+        document.getElementById("sidebar")?.classList.remove("hidden");
+        document.getElementById("main-content")?.classList.remove("hidden");
+    }
+
 
     /**
      * Inizializzazione del dashboard
@@ -39,7 +44,7 @@ class DashboardManager {
         await this.generateCSRFToken();
         this.setupEventListeners();
         this.setupSidebar();
-        this.loadUserData();
+        await this.loadUserData();
         this.loadUserSettings();
         this.setupTheme();
         this.setupFormValidation();
@@ -298,6 +303,7 @@ class DashboardManager {
 
             if (data.success) {
                 this.populateUserData(data.data);
+                this.showPage();
             } else {
                 this.showNotification('Errore nel caricamento dei dati utente', 'error');
             }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -15,7 +15,7 @@
   <!-- HEADER_PLACEHOLDER -->
 
   <!-- Sidebar -->
-  <aside class="sidebar" id="sidebar">
+  <aside class="sidebar hidden" id="sidebar">
     <div class="sidebar-header">
       <h2>Menu</h2>
     </div>
@@ -45,7 +45,7 @@
   </aside>
 
   <!-- Main Content -->
-  <main id="main-content" class="main-content">
+  <main id="main-content" class="main-content hidden">
     <div class="content-wrapper">
 
       <!-- Sezione Il mio profilo -->
@@ -351,7 +351,7 @@
   <!-- Overlay per mobile -->
   <div class="overlay" id="overlay"></div>
   <!-- Overlay di caricamento -->
-  <div class="loading-overlay" id="loadingOverlay" role="status" aria-live="polite">Caricamento in corso...</div>
+  <div class="loading-overlay active" id="loadingOverlay" role="status" aria-live="polite">Caricamento in corso...</div>
 
   <!-- FOOTER_PLACEHOLDER -->
 


### PR DESCRIPTION
## Summary
- hide sidebar and main content until user data loads
- start with loading overlay active
- reveal dashboard content through new `showPage()` helper
- make init wait for user data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d244d207c83218aae832849f402ec