### PR TITLE
Fix dashboard loading visibility

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -34,6 +34,7 @@ class DashboardManager {
     showPage() {
         document.getElementById("sidebar")?.classList.remove("hidden");
         document.getElementById("main-content")?.classList.remove("hidden");
+        document.getElementById("dashboardFooter")?.classList.remove("hidden");
     }
 
 

--- a/php/dashboard.php
+++ b/php/dashboard.php
@@ -10,6 +10,7 @@ SessionManager::requireLogin();
 
 $header = file_get_contents("../static/header.html");
 $footer = file_get_contents("../static/footer.html");
+$footer = str_replace('<footer', '<footer class="hidden" id="dashboardFooter"', $footer);
 $DOM = file_get_contents("../static/dashboard.html");
 
 $DOM = str_replace("<!-- HEADER_PLACEHOLDER -->", $header, $DOM);


### PR DESCRIPTION
## Summary
- hide footer in dashboard by default
- reveal footer when dashboard content is ready

## Testing
- `php -S localhost:8000` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d266860a88321a121fc298f79a7fe