### PR TITLE
Fix admin review list toggle and remove sidebar header

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -566,11 +566,16 @@ body {
   margin-bottom: var(--spacing-md);
   transition: var(--transition);
   background: var(--surface);
+  flex-direction: column;
 }
 
 .review-item:hover {
   box-shadow: var(--shadow-md);
   transform: translateY(-0.125rem);
+}
+
+.review-summary {
+  cursor: pointer;
 }
 
 .review-image {
@@ -579,6 +584,15 @@ body {
   border-radius: var(--radius-sm);
   object-fit: cover;
   flex-shrink: 0;
+  margin-bottom: var(--spacing-sm);
+}
+
+.review-details {
+  margin-top: var(--spacing-sm);
+}
+
+.review-details.hidden {
+  display: none;
 }
 
 .review-content {

--- a/js/gestione_recensioni.js
+++ b/js/gestione_recensioni.js
@@ -38,16 +38,33 @@ document.addEventListener('DOMContentLoaded', async () => {
       const data = await res.json();
       if (data.success) {
         list.innerHTML = data.data.reviews.map(r => `
-          <div class="review-item" data-id="${r.id}" data-product="${escapeHtml(r.product_name)}" data-image="${escapeHtml(r.product_image || '')}" data-rating="${r.rating}">
-            <h3>${escapeHtml(r.title)}</h3>
-            <p class="review-author">${escapeHtml(r.username || '')}</p>
-            <p>${escapeHtml(r.content)}</p>
-            <div class="review-actions">
-              <button class="edit-btn" data-id="${r.id}">Modifica</button>
-              <button class="delete-btn" data-id="${r.id}">Elimina</button>
+          <div class="review-item" data-id="${r.id}" data-product="${escapeHtml(r.product_name)}" data-image="${escapeHtml(r.product_image || '')}" data-rating="${r.rating}" data-content="${escapeHtml(r.content)}" data-title="${escapeHtml(r.title)}">
+            <div class="review-summary">
+              <h3>${escapeHtml(r.title)}</h3>
+              <p class="review-author">${escapeHtml(r.username || '')}</p>
+            </div>
+            <div class="review-details">
+              ${r.product_image ? `<img src="${escapeHtml(r.product_image)}" alt="${escapeHtml(r.product_name)}" class="review-image">` : ''}
+              <p><strong>Prodotto:</strong> ${escapeHtml(r.product_name)}</p>
+              <p><strong>Valutazione:</strong> ${r.rating}</p>
+              <p>${escapeHtml(r.content)}</p>
+              <div class="review-actions">
+                <button class="edit-btn" data-id="${r.id}">Modifica</button>
+                <button class="delete-btn" data-id="${r.id}">Elimina</button>
+              </div>
             </div>
           </div>
         `).join('');
+
+        document.querySelectorAll('.review-details').forEach(d => d.classList.add('hidden'));
+        document.querySelectorAll('.review-summary').forEach(sum => {
+          sum.addEventListener('click', () => {
+            const item = sum.closest('.review-item');
+            const details = item.querySelector('.review-details');
+            item.classList.toggle('expanded');
+            details.classList.toggle('hidden');
+          });
+        });
       } else {
         list.textContent = 'Errore nel caricamento delle recensioni';
       }
@@ -121,12 +138,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     } else if (e.target.classList.contains('edit-btn')) {
       const item = e.target.closest('.review-item');
-      form.title.value = item.querySelector('h3').textContent;
+      form.title.value = item.dataset.title || '';
       form.product.value = item.dataset.product || '';
       form.rating.value = item.dataset.rating || 5;
       form.image.value = '';
       form.old_image.value = item.dataset.image || '';
-      form.content.value = item.querySelector('p').textContent;
+      form.content.value = item.dataset.content || '';
       form.dataset.editId = e.target.dataset.id;
       submitBtn.textContent = 'Aggiorna';
       window.scrollTo({ top: form.offsetTop, behavior: 'smooth' });

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -16,9 +16,6 @@
 
   <!-- Sidebar -->
   <aside class="sidebar hidden" id="sidebar">
-    <div class="sidebar-header">
-      <h2>Menu</h2>
-    </div>
 
     <nav class="sidebar-nav">
       <ul class="nav-menu">

--- a/static/gestione_recensioni.html
+++ b/static/gestione_recensioni.html
@@ -15,9 +15,6 @@
   <!-- HEADER_PLACEHOLDER -->
 
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-header">
-      <h2>Menu</h2>
-    </div>
     <nav class="sidebar-nav">
       <ul class="nav-menu">
         <li class="nav-item active">


### PR DESCRIPTION
## Summary
- remove sidebar "Menu" text in dashboard and admin pages
- allow admin review items to expand to show details and image
- enable edit function to use item data
- add styles for collapsible review details

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685d477e01b88321af0a5ce5219020eb