### PR TITLE
Fix admin review API path

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -56,7 +56,7 @@ class DashboardManager {
      */
     async generateCSRFToken() {
         try {
-            const response = await fetch('../php/api.php?endpoint=csrf_token');
+            const response = await fetch('/php/api.php?endpoint=csrf_token');
             const data = await response.json();
             if (data.csrf_token) {
                 this.csrfToken = data.csrf_token;
@@ -293,7 +293,7 @@ class DashboardManager {
     async loadUserData() {
         this.showLoading();
         try {
-            const response = await fetch('../php/api.php?endpoint=profile');
+            const response = await fetch('/php/api.php?endpoint=profile');
             const data = await response.json();
 
             if (data.success) {
@@ -382,7 +382,7 @@ class DashboardManager {
         };
 
         try {
-            const response = await fetch('../php/api.php?endpoint=profile', {
+            const response = await fetch('/php/api.php?endpoint=profile', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -428,7 +428,7 @@ class DashboardManager {
         formData.append('csrf_token', this.csrfToken);
 
         try {
-            const response = await fetch('../php/api.php?endpoint=actions&action=upload_photo', {
+            const response = await fetch('/php/api.php?endpoint=actions&action=upload_photo', {
                 method: 'POST',
                 body: formData
             });
@@ -467,7 +467,7 @@ class DashboardManager {
         };
 
         try {
-            const response = await fetch('../php/api.php?endpoint=actions&action=change_password', {
+            const response = await fetch('/php/api.php?endpoint=actions&action=change_password', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -502,7 +502,7 @@ class DashboardManager {
         }
 
         try {
-            const response = await fetch('../php/api.php?endpoint=profile', {
+            const response = await fetch('/php/api.php?endpoint=profile', {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',
@@ -546,7 +546,7 @@ class DashboardManager {
         });
 
         try {
-            const response = await fetch(`../php/api.php?endpoint=reviews&${params}`);
+            const response = await fetch(`/php/api.php?endpoint=reviews&${params}`);
             const data = await response.json();
 
             if (data.success) {
@@ -676,7 +676,7 @@ class DashboardManager {
         }
 
         try {
-            const response = await fetch(`../php/api.php?endpoint=reviews&id=${reviewId}`, {
+            const response = await fetch(`/php/api.php?endpoint=reviews&id=${reviewId}`, {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',
@@ -705,7 +705,7 @@ class DashboardManager {
      */
     async loadUserSettings() {
         try {
-            const response = await fetch('../php/api.php?endpoint=settings', {
+            const response = await fetch('/php/api.php?endpoint=settings', {
                 method: 'GET',
                 headers: {
                     'X-Requested-With': 'XMLHttpRequest'
@@ -774,7 +774,7 @@ class DashboardManager {
         };
 
         try {
-            const response = await fetch('../php/api.php?endpoint=settings', {
+            const response = await fetch('/php/api.php?endpoint=settings', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/js/gestione_recensioni.js
+++ b/js/gestione_recensioni.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   async function loadCSRF() {
     try {
-      const res = await fetch('../php/api.php?endpoint=csrf_token');
+      const res = await fetch('/php/api.php?endpoint=csrf_token');
       const data = await res.json();
       csrfToken = data.csrf_token || '';
     } catch (e) {
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   async function loadReviews() {
     try {
-      const res = await fetch('../php/api.php?endpoint=reviews&limit=20&all=1');
+      const res = await fetch('/php/api.php?endpoint=reviews&limit=20&all=1');
       const data = await res.json();
       if (data.success) {
         list.innerHTML = data.data.reviews.map(r => `
@@ -75,7 +75,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   async function createReview(formData) {
     formData.append('csrf_token', csrfToken);
-    const res = await fetch('../php/api.php?endpoint=reviews', {
+    const res = await fetch('/php/api.php?endpoint=reviews', {
       method: 'POST',
       body: formData
     });
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   async function updateReview(id, formData) {
     formData.append('csrf_token', csrfToken);
     formData.append('_method', 'PUT');
-    const res = await fetch(`../php/api.php?endpoint=reviews?id=${id}`, {
+    const res = await fetch(`/php/api.php?endpoint=reviews?id=${id}`, {
       method: 'POST',
       body: formData
     });
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function deleteReview(id) {
-    const res = await fetch(`../php/api.php?endpoint=reviews?id=${id}`, {
+    const res = await fetch(`/php/api.php?endpoint=reviews?id=${id}`, {
       method: 'DELETE',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ csrf_token: csrfToken })


### PR DESCRIPTION
## Summary
- fix admin review API requests
- use absolute path for all dashboard API calls

## Testing
- `grep -R "../php/api.php" -n js`

------
https://chatgpt.com/codex/tasks/task_b_685d52c79dd883218f3aee7feb20d5bd