### PR TITLE
Remove review editing and update deletion modal

### DIFF
--- a/php/gestione_recensioni.php
+++ b/php/gestione_recensioni.php
@@ -2,7 +2,7 @@
 /**
  * Pagina di gestione delle recensioni (solo admin)
  *
- * Consente di pubblicare, modificare ed eliminare recensioni
+ * Consente di pubblicare ed eliminare recensioni
  */
 
 require_once 'database.php';

--- a/static/gestione_recensioni.html
+++ b/static/gestione_recensioni.html
@@ -38,7 +38,7 @@
       <section id="visualizza-section" class="content-section active">
         <div class="section-header">
           <h1>Gestione Recensioni</h1>
-          <p>Aggiungi, modifica o elimina le recensioni</p>
+          <p>Aggiungi o elimina le recensioni</p>
         </div>
 
         <div id="reviews-list"></div>
@@ -65,7 +65,6 @@
           <div class="form-group">
             <label for="review-image">Immagine prodotto</label>
             <input type="file" id="review-image" name="image" aria-required="false" accept="image/*">
-            <input type="hidden" id="old-image" name="old_image">
           </div>
           <div class="form-group">
             <label for="review-content">Contenuto</label>
@@ -76,6 +75,32 @@
       </section>
     </div>
   </main>
+
+  <!-- Modal per conferma eliminazione recensione -->
+  <div class="modal" id="deleteReviewModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Elimina recensione</h3>
+        <button class="modal-close" id="deleteReviewModalClose">
+          <i aria-hidden="true" class="fas fa-times"></i>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="warning-message">
+          <i aria-hidden="true" class="fas fa-exclamation-triangle"></i>
+          <p>Sei sicuro di voler eliminare questa recensione? Questa azione è irreversibile.</p>
+        </div>
+        <div class="form-group">
+          <label for="deleteReviewConfirmation">Digita "ELIMINA" per confermare:</label>
+          <input type="text" id="deleteReviewConfirmation" placeholder="ELIMINA">
+        </div>
+        <div class="modal-actions">
+          <button type="button" class="btn btn-secondary" id="cancelReviewDeleteBtn">Annulla</button>
+          <button type="button" class="btn btn-danger" id="confirmReviewDeleteBtn" disabled>Elimina</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div class="overlay" id="overlay"></div>
 


### PR DESCRIPTION
## Summary
- drop edit-review UI from gestione recensioni
- add a modal for deleting reviews styled like the account deletion modal
- clean up JS logic and comments

## Testing
- `node --check js/auth-validation.js`
- `node --check js/dashboard.js`
- `node --check js/gestione_recensioni.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_b_685d6dd75f688321ab65ffe71a1b9ecc