### PR TITLE
Fix deletion check

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -648,7 +648,7 @@ class DashboardManager {
         }
 
         try {
-            const response = await fetch(`api.php?endpoint=reviews&id=${reviewId}`, {
+            const response = await fetch(`api.php?endpoint=delete&id=${reviewId}`, {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',

--- a/js/gestione_recensioni.js
+++ b/js/gestione_recensioni.js
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
   async function deleteReview(id) {
-    const res = await fetch(`api.php?endpoint=reviews&id=${id}`, {
+    const res = await fetch(`api.php?endpoint=delete&id=${id}`, {
       method: 'DELETE',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({})

--- a/php/api.php
+++ b/php/api.php
@@ -40,6 +40,9 @@ switch ($endpoint) {
     case 'reviews':
         handle_reviews($userId, $reviewManager);
         break;
+    case 'delete':
+        handle_delete($userId, $reviewManager);
+        break;
     case 'settings':
         handle_settings($userId, $settingsManager);
         break;
@@ -321,8 +324,8 @@ function handle_reviews($userId, $reviewManager) {
                 if ($deleted) {
                     echo json_encode(['success' => true, 'message' => 'Recensione eliminata con successo']);
                 } else {
-                    http_response_code(500);
-                    echo json_encode(['success' => false, 'message' => "Errore durante l'eliminazione"]);
+                    http_response_code(404);
+                    echo json_encode(['success' => false, 'message' => 'Recensione non trovata']);
                 }
                 break;
             default:
@@ -333,6 +336,28 @@ function handle_reviews($userId, $reviewManager) {
         error_log('Errore API recensioni: ' . $e->getMessage());
         http_response_code(500);
         echo json_encode(['success' => false, 'message' => 'Errore interno del server']);
+    }
+}
+
+function handle_delete($userId, $reviewManager) {
+    $isAdmin = isset($_SESSION['role']) && $_SESSION['role'] === 'admin';
+    if ($_SERVER['REQUEST_METHOD'] !== 'DELETE') {
+        http_response_code(405);
+        echo json_encode(['success' => false, 'message' => 'Metodo non supportato']);
+        return;
+    }
+    $reviewId = (int)($_GET['id'] ?? 0);
+    if (!$reviewId) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'ID recensione mancante']);
+        return;
+    }
+    $deleted = $reviewManager->deleteReview($reviewId, $isAdmin ? null : $userId);
+    if ($deleted) {
+        echo json_encode(['success' => true, 'message' => 'Recensione eliminata con successo']);
+    } else {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Recensione non trovata']);
     }
 }
 

--- a/php/database.php
+++ b/php/database.php
@@ -337,10 +337,12 @@ class ReviewManager {
         try {
             if ($userId === null) {
                 $stmt = $this->db->prepare("UPDATE reviews SET deleted_at = NOW() WHERE id = ? AND deleted_at IS NULL");
-                return $stmt->execute([$reviewId]);
+                $stmt->execute([$reviewId]);
+            } else {
+                $stmt = $this->db->prepare("UPDATE reviews SET deleted_at = NOW() WHERE id = ? AND user_id = ? AND deleted_at IS NULL");
+                $stmt->execute([$reviewId, $userId]);
             }
-            $stmt = $this->db->prepare("UPDATE reviews SET deleted_at = NOW() WHERE id = ? AND user_id = ? AND deleted_at IS NULL");
-            return $stmt->execute([$reviewId, $userId]);
+            return $stmt->rowCount() > 0;
         } catch (PDOException $e) {
             error_log("Errore deleteReview: " . $e->getMessage());
             return false;


### PR DESCRIPTION
## Summary
- ensure the deleteReview DB method checks that a row was actually updated
- return 404 when the review is not found
- rename the review deletion endpoint to `delete`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d7b7f07d88321a13f76ae25662ae2