### PR TITLE
Update header avatar sync

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,16 @@ require_once 'php/database.php';
 // Avvio della sessione
 SessionManager::start();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 // Caricamento di header e footer comuni
 $header = file_get_contents("static/header.html");
 $footer = file_get_contents("static/footer.html");

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -15,6 +15,16 @@ require_once 'database.php';
 // Avvio della sessione
 SessionManager::start();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 // Caricamento di header e footer comuni
 $header = file_get_contents("../static/header.html");
 $footer = file_get_contents("../static/footer.html");

--- a/php/contatti.php
+++ b/php/contatti.php
@@ -14,6 +14,16 @@ require_once 'database.php';
 // Avvio della sessione
 SessionManager::start();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 // Caricamento di header e footer comuni
 $header = file_get_contents("../static/header.html");
 $footer = file_get_contents("../static/footer.html");

--- a/php/dashboard.php
+++ b/php/dashboard.php
@@ -8,6 +8,16 @@ require_once 'database.php';
 SessionManager::start();
 SessionManager::requireLogin();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 $header = file_get_contents("../static/header.html");
 $footer = file_get_contents("../static/footer.html");
 $footer = str_replace('<footer', '<footer class="hidden" id="dashboardFooter"', $footer);

--- a/php/gestione_recensioni.php
+++ b/php/gestione_recensioni.php
@@ -10,6 +10,16 @@ require_once 'database.php';
 SessionManager::start();
 SessionManager::requireLogin();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
     http_response_code(403);
     echo 'Accesso negato';

--- a/php/recensione.php
+++ b/php/recensione.php
@@ -6,6 +6,16 @@ require_once 'database.php';
 
 SessionManager::start();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 $reviewId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if (!$reviewId) {
     http_response_code(404);

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -15,6 +15,16 @@ require_once 'database.php';
 // Avvio della sessione
 SessionManager::start();
 
+// Sincronizza i dati dell'utente con il database per ottenere l'ultima foto profilo
+if (SessionManager::isLoggedIn()) {
+    $userManager = new UserManager();
+    $user = $userManager->getUserById(SessionManager::getUserId());
+    if ($user) {
+        $_SESSION['user_data']['profile_photo'] = $user['profile_photo'];
+        $_SESSION['profile_photo'] = $user['profile_photo'];
+    }
+}
+
 // Caricamento di header e footer comuni
 $header = file_get_contents("../static/header.html");
 $footer = file_get_contents("../static/footer.html");


### PR DESCRIPTION
## Summary
- ensure user avatar path is refreshed from database
- apply update on all PHP pages that inject the dynamic header

## Testing
- `php -l index.php php/classifiche.php php/contatti.php php/dashboard.php php/gestione_recensioni.php php/recensione.php php/recensioni.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685ee2e213ac8321bfaa9acd51827ce9