### PR TITLE
Fix photo upload cancel

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -104,7 +104,11 @@ class DashboardManager {
         const changePhotoBtn = document.getElementById('changePhotoBtn');
         const photoInput = document.getElementById('photoInput');
         if (changePhotoBtn && photoInput) {
-            changePhotoBtn.addEventListener('click', () => photoInput.click());
+            changePhotoBtn.addEventListener('click', () => {
+                // Reset del valore per evitare invii indesiderati se l'utente annulla la selezione
+                photoInput.value = '';
+                photoInput.click();
+            });
             photoInput.addEventListener('change', (e) => this.handlePhotoUpload(e));
         }
 


### PR DESCRIPTION
## Summary
- avoid phantom photo uploads by clearing `photoInput` before opening the file dialog

## Testing
- `node --check js/dashboard.js`

------
https://chatgpt.com/codex/tasks/task_b_685ee5125bb08321b923318015a19343