### PR TITLE
Fix user dropdown width on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -749,6 +749,11 @@ nav {
     justify-content: center;
   }
 
+  .user-dropdown {
+    width: auto;
+    min-width: 12rem;
+  }
+
   .nav-links {
     padding: 1.5rem;
     gap: 0.75rem;


### PR DESCRIPTION
## Summary
- tweak mobile layout for user dropdown so text fits on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685eed92858c8321858a6398b4a5be40