### PR TITLE
Adjust rating layout on rankings page

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -762,8 +762,8 @@
 
 .rating-display {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  flex-direction: row;
+  align-items: center;
   gap: var(--spacing-xs);
 }
 


### PR DESCRIPTION
## Summary
- keep rating display horizontal in ranking table to align with product info

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_685f84524a348321b3d416351855e949