### PR TITLE
Fix ranking layout

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -739,6 +739,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
+  white-space: nowrap;
 }
 
 .product-image {
@@ -765,6 +766,7 @@
   flex-direction: row;
   align-items: center;
   gap: var(--spacing-xs);
+  white-space: nowrap;
 }
 
 .rating-stars {

--- a/css/style.css
+++ b/css/style.css
@@ -427,7 +427,8 @@ nav {
 
 /* Disable pointer events on the current page link */
 .nav-links a[aria-current="page"],
-.logo-link[aria-current="page"] {
+.logo-link[aria-current="page"],
+.user-dropdown a[aria-current="page"] {
   pointer-events: none;
   cursor: default;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -71,7 +71,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Disable navigation link for the current page
   const currentPage = window.location.pathname.split('/').pop();
-  const navAnchors = document.querySelectorAll('.nav-links a, .logo-link');
+  const navAnchors = document.querySelectorAll('.nav-links a, .logo-link, .user-dropdown a');
   navAnchors.forEach((link) => {
     const linkPage = new URL(link.href).pathname.split('/').pop();
     if (linkPage === currentPage) {

--- a/php/gestione_recensioni.php
+++ b/php/gestione_recensioni.php
@@ -44,12 +44,11 @@ $headerLoginHtml = " <div class='login-link user-menu' role='button' tabindex='0
                         <span class='login-text'>{$username}</span>
                         <div class='user-dropdown'>
                           <a href='dashboard.php'><span lang='en'>Dashboard</span></a>
+                          <a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>
                           <a href='logout.php'><span lang='en'>Logout</span></a>
                         </div>
                       </div>";
 
-//<a href='gestione_recensioni.php'><span>Gestione recensioni</span></a> tolto perchè se sono nella pagina corrente per acc. non ha senso renderlo cliccabile, migliora la fluidità per i screenreader
-//Oppure possiamo renderlo non cliccabile
 $DOM = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $DOM);
 
 echo $DOM;


### PR DESCRIPTION
## Summary
- keep rating display inline with product info on ranking page
- disable user dropdown link for the current page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685f9c4158fc8321be563319331fd19d