### PR TITLE
Refactor dropdown to click-activated user menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -247,7 +247,7 @@ a:focus {
   cursor: pointer;
 }
 
-.user-dropdown {
+.user-menu-panel {
   position: absolute;
   top: 100%;
   right: 0;
@@ -259,18 +259,17 @@ a:focus {
   overflow: hidden;
   opacity: 0;
   visibility: hidden;
-  transform: translateY(0.625rem);
+  transform: translateX(0.625rem);
   transition: var(--transition);
 }
 
-.user-menu:hover .user-dropdown,
-.user-menu:focus-within .user-dropdown {
+.user-menu-panel.open {
   opacity: 1;
   visibility: visible;
-  transform: translateY(0);
+  transform: translateX(0);
 }
 
-.user-dropdown a {
+.user-menu-panel a {
   display: block;
   padding: var(--spacing-sm) var(--spacing-md);
   color: var(--text-primary);
@@ -279,14 +278,14 @@ a:focus {
   border-left: 0.1875rem solid transparent;
 }
 
-.user-dropdown a:hover {
+.user-menu-panel a:hover {
   background: var(--background);
   color: var(--primary-agid);
   border-left-color: var(--primary-agid);
   text-decoration: none;
 }
 
-.user-dropdown a:not(:last-child) {
+.user-menu-panel a:not(:last-child) {
   border-bottom: 0.0625rem solid var(--border);
 }
 
@@ -302,7 +301,7 @@ a:focus {
     padding-top: 0;
   }
 
-  .user-dropdown {
+  .user-menu-panel {
     display: none;
   }
 }
@@ -428,7 +427,7 @@ nav {
 /* Disable pointer events on the current page link */
 .nav-links a[aria-current="page"],
 .logo-link[aria-current="page"],
-.user-dropdown a[aria-current="page"] {
+.user-menu-panel a[aria-current="page"] {
   pointer-events: none;
   cursor: default;
   text-decoration: underline;
@@ -706,7 +705,7 @@ nav {
     justify-content: center;
   }
 
-  .user-dropdown {
+  .user-menu-panel {
     width: auto;
     min-width: 12rem;
   }

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if (!SessionManager::isLoggedIn()) {
       {$icon}
     </div>
     <div class='login-text'>{$username}</div>
-    <div class='user-dropdown'>
+    <div class='user-menu-panel' aria-hidden='true'>
       <a href='php/dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "

--- a/js/main.js
+++ b/js/main.js
@@ -29,6 +29,39 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  const userMenus = document.querySelectorAll('.user-menu');
+  if (userMenus.length) {
+    userMenus.forEach((menu) => {
+      const panel = menu.querySelector('.user-menu-panel');
+      if (!panel) return;
+
+      menu.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const isOpen = panel.classList.toggle('open');
+        menu.setAttribute('aria-expanded', isOpen);
+        panel.setAttribute('aria-hidden', !isOpen);
+      });
+
+      menu.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          menu.click();
+        }
+      });
+    });
+
+    document.addEventListener('click', () => {
+      userMenus.forEach((menu) => {
+        const panel = menu.querySelector('.user-menu-panel');
+        if (panel && panel.classList.contains('open')) {
+          panel.classList.remove('open');
+          menu.setAttribute('aria-expanded', 'false');
+          panel.setAttribute('aria-hidden', 'true');
+        }
+      });
+    });
+  }
+
   const commentForm = document.getElementById('comment-form');
   if (commentForm) {
     commentForm.addEventListener('submit', async (e) => {
@@ -71,7 +104,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Disable navigation link for the current page
   const currentPage = window.location.pathname.split('/').pop();
-  const navAnchors = document.querySelectorAll('.nav-links a, .logo-link, .user-dropdown a');
+  const navAnchors = document.querySelectorAll('.nav-links a, .logo-link, .user-menu-panel a');
   navAnchors.forEach((link) => {
     const linkPage = new URL(link.href).pathname.split('/').pop();
     if (linkPage === currentPage) {

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -71,7 +71,7 @@ if (!SessionManager::isLoggedIn()) {
       {$icon}
     </div>
     <span class='login-text'>{$username}</span>
-    <div class='user-dropdown'>
+    <div class='user-menu-panel' aria-hidden='true'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "

--- a/php/contatti.php
+++ b/php/contatti.php
@@ -71,7 +71,7 @@ if (!SessionManager::isLoggedIn()) {
       {$icon}
     </div>
     <span class='login-text'>{$username}</span>
-    <div class='user-dropdown'>
+    <div class='user-menu-panel' aria-hidden='true'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "
@@ -87,7 +87,7 @@ if (!SessionManager::isLoggedIn()) {
                           {$icon}
                         </div>
                         <span class='login-text'>{$username}</span>
-                        <div class='user-dropdown'>
+                        <div class='user-menu-panel' aria-hidden='true'>
                           <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
   if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
       $headerLoginHtml .= "\n                          <a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>";

--- a/php/dashboard.php
+++ b/php/dashboard.php
@@ -36,7 +36,7 @@ $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$us
       {$icon}
     </div>
     <span class='login-text'>{$username}</span>
-    <div class='user-dropdown'>
+    <div class='user-menu-panel' aria-hidden='true'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
 
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {

--- a/php/gestione_recensioni.php
+++ b/php/gestione_recensioni.php
@@ -42,7 +42,7 @@ $headerLoginHtml = " <div class='login-link user-menu' role='button' tabindex='0
                           {$icon}
                         </div>
                         <span class='login-text'>{$username}</span>
-                        <div class='user-dropdown'>
+                        <div class='user-menu-panel' aria-hidden='true'>
                           <a href='dashboard.php'><span lang='en'>Dashboard</span></a>
                           <a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>
                           <a href='logout.php'><span lang='en'>Logout</span></a>

--- a/php/recensione.php
+++ b/php/recensione.php
@@ -50,7 +50,7 @@ if (!SessionManager::isLoggedIn()) {
     $username = $_SESSION['username'];
     $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
     $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
-    $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'><div class='user-icon-bg'>{$icon}</div><span class='login-text'>{$username}</span><div class='user-dropdown'><a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
+    $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'><div class='user-icon-bg'>{$icon}</div><span class='login-text'>{$username}</span><div class='user-menu-panel' aria-hidden='true'><a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "<a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>";
     }

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -71,7 +71,7 @@ if (!SessionManager::isLoggedIn()) {
       {$icon}
     </div>
     <span class='login-text'>{$username}</span>
-    <div class='user-dropdown'>
+    <div class='user-menu-panel' aria-hidden='true'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "


### PR DESCRIPTION
## Summary
- rename `.user-dropdown` to `.user-menu-panel`
- add click-based toggle logic for the user menu
- update header markup across PHP pages
- adjust styles so the menu slides in from the right

## Testing
- `npx eslint js/main.js`

------
https://chatgpt.com/codex/tasks/task_b_685fa7d6fa7483218802190714e507ba