### PR TITLE
Update comment form to use logged-in user info

### DIFF
--- a/php/api.php
+++ b/php/api.php
@@ -379,11 +379,18 @@ function handle_comments($commentManager) {
     try {
         switch ($_SERVER['REQUEST_METHOD']) {
             case 'POST':
+                if (!SessionManager::isLoggedIn()) {
+                    http_response_code(401);
+                    echo json_encode(['success' => false, 'message' => 'Utente non autenticato']);
+                    break;
+                }
+
                 $reviewId = (int)($_POST['review_id'] ?? 0);
-                $name = Utils::sanitizeInput($_POST['name'] ?? '');
-                $email = Utils::sanitizeInput($_POST['email'] ?? '');
                 $star = min(5, max(1, intval($_POST['star'] ?? 1)));
                 $content = Utils::sanitizeInput($_POST['content'] ?? '');
+                $name = $_SESSION['user_data']['username'] ?? '';
+                $email = $_SESSION['user_data']['email'] ?? '';
+
                 if ($reviewId && $name && $email && $content) {
                     if ($commentManager->createComment($reviewId, $name, $email, $star, $content)) {
                         echo json_encode(['success' => true]);

--- a/static/recensione.html
+++ b/static/recensione.html
@@ -41,14 +41,6 @@
       <form id="comment-form" method="post" class="comment-form">
         <input type="hidden" name="review_id" value="<!--ID_PLACEHOLDER-->">
         <div class="form-group">
-          <label for="comment-name" class="form-label required">Nome</label>
-          <input type="text" id="comment-name" name="name" class="form-input" required>
-        </div>
-        <div class="form-group">
-          <label for="comment-email" class="form-label required">Email</label>
-          <input type="email" id="comment-email" name="email" class="form-input" required>
-        </div>
-        <div class="form-group">
           <label for="comment-star" class="form-label required">Valutazione</label>
           <select id="comment-star" name="star" class="form-select" required>
             <option value="5">5</option>


### PR DESCRIPTION
## Summary
- remove name/email fields from `Lascia un tuo opinione` form
- capture commenter name and email from session in API

## Testing
- `npx eslint js/main.js` *(fails: npm config http-proxy)*

------
https://chatgpt.com/codex/tasks/task_b_685fb8b86c9c8321acdd39948a905ba2