### PR TITLE
Implement single comment per user

### DIFF
--- a/php/database.php
+++ b/php/database.php
@@ -484,6 +484,20 @@ class CommentManager {
     }
 
     /**
+     * Ottiene il commento di un utente per una specifica recensione
+     */
+    public function getUserCommentForReview($reviewId, $email) {
+        try {
+            $stmt = $this->db->prepare("SELECT id, star, content, created_at FROM comments WHERE review_id = ? AND email = ?");
+            $stmt->execute([$reviewId, $email]);
+            return $stmt->fetch();
+        } catch (PDOException $e) {
+            error_log('Errore getUserCommentForReview: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
      * Ottiene i commenti di un utente con paginazione e filtri
      */
     public function getUserComments($email, $page = 1, $limit = 10, $filters = []) {

--- a/static/recensione.html
+++ b/static/recensione.html
@@ -38,21 +38,18 @@
 
     <section class="comments-section content-box" aria-labelledby="opinione-title">
       <h2 id="opinione-title">Lascia un tuo opinione</h2>
+      <div id="user-comment-info"></div>
       <form id="comment-form" method="post" class="comment-form">
         <input type="hidden" name="review_id" value="<!--ID_PLACEHOLDER-->">
         <div class="form-group">
           <label for="comment-star" class="form-label required">Valutazione</label>
           <select id="comment-star" name="star" class="form-select" required>
-            <option value="5">5</option>
-            <option value="4">4</option>
-            <option value="3">3</option>
-            <option value="2">2</option>
-            <option value="1" selected>1</option>
+            <!--STAR_OPTIONS-->
           </select>
         </div>
         <div class="form-group">
           <label for="comment-content" class="form-label required">Commento</label>
-          <textarea id="comment-content" name="content" class="form-textarea" required></textarea>
+          <textarea id="comment-content" name="content" class="form-textarea" required><!--COMMENT_CONTENT--></textarea>
         </div>
         <button type="submit" class="form-submit">Invia</button>
       </form>


### PR DESCRIPTION
## Summary
- enforce single comment retrieval logic
- adjust recensione view to display/update the user's own comment
- update recensione template for editable comment form

## Testing
- `php -l php/recensione.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685fc4685bf4832193701d59f57cfeb5