### PR TITLE
Fix homepage link disabled

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -103,7 +103,10 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Disable navigation link for the current page
-  const currentPage = window.location.pathname.split('/').pop();
+  let currentPage = window.location.pathname.split('/').pop();
+  if (!currentPage) {
+    currentPage = 'index.php';
+  }
   const navAnchors = document.querySelectorAll('.nav-links a, .logo-link, .user-menu-panel a');
   navAnchors.forEach((link) => {
     const linkPage = new URL(link.href).pathname.split('/').pop();


### PR DESCRIPTION
## Summary
- fix detection for the current page so home links are disabled when landing on the site root

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_b_685fd1b8b9548321909767200e582664