### PR TITLE
Enforce 60 char limit on product names

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE reviews (
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
     rating INT NOT NULL,
-    product_name VARCHAR(255) NOT NULL,
+    product_name VARCHAR(60) NOT NULL,
     product_image VARCHAR(255),      -- Path to product image
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NULL DEFAULT NULL,

--- a/php/api.php
+++ b/php/api.php
@@ -265,6 +265,11 @@ function handle_reviews($userId, $reviewManager) {
                 if ($data['rating'] < 1 || $data['rating'] > 5) {
                     $errors[] = 'La valutazione deve essere tra 1 e 5 stelle';
                 }
+                if (empty($data['product_name'])) {
+                    $errors[] = 'Il nome del prodotto è obbligatorio';
+                } elseif (strlen($data['product_name']) > 60) {
+                    $errors[] = 'Il nome del prodotto non può superare 60 caratteri';
+                }
                 if (!empty($errors)) {
                     http_response_code(400);
                     echo json_encode(['success' => false, 'message' => implode(', ', $errors)]);
@@ -312,6 +317,11 @@ function handle_reviews($userId, $reviewManager) {
                 }
                 if ($data['rating'] < 1 || $data['rating'] > 5) {
                     $errors[] = 'La valutazione deve essere tra 1 e 5 stelle';
+                }
+                if (empty($data['product_name'])) {
+                    $errors[] = 'Il nome del prodotto è obbligatorio';
+                } elseif (strlen($data['product_name']) > 60) {
+                    $errors[] = 'Il nome del prodotto non può superare 60 caratteri';
                 }
                 if (!empty($errors)) {
                     http_response_code(400);

--- a/static/gestione_recensioni.html
+++ b/static/gestione_recensioni.html
@@ -65,7 +65,7 @@
           </div>
           <div class="form-group">
             <label for="review-product">Prodotto</label>
-            <input type="text" id="review-product" name="product" required aria-required="true">
+            <input type="text" id="review-product" name="product" required aria-required="true" maxlength="60">
           </div>
           <div class="form-group">
             <label for="review-rating">Valutazione (1-5)</label>


### PR DESCRIPTION
## Summary
- add `maxlength` to product name field
- limit `product_name` to 60 characters in schema
- validate product name length in review API

## Testing
- `php -l php/api.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685ff38ca9508321a9c540352c50a95c