### PR TITLE
Remove truncateAltText usage

### DIFF
--- a/index.php
+++ b/index.php
@@ -98,8 +98,8 @@ if ($result !== false) {
         $stars = Utils::generateStars($review['rating']);
         $excerpt = strlen($review['content']) > 150 ? substr($review['content'], 0, 150) . '...' : $review['content'];
         $date = Utils::formatDate($review['created_at']);
-        $altProduct = Utils::truncateAltText($review['product_name']);
-        $img = $review['product_image'] ? "<img src='../{$review['product_image']}' alt='" . htmlspecialchars($altProduct) . "' class='review-image'>" : '';
+        $altProduct = htmlspecialchars($review['product_name']);
+        $img = $review['product_image'] ? "<img src='../{$review['product_image']}' alt='{$altProduct}' class='review-image'>" : '';
         $title = htmlspecialchars($review['title']);
         $user = htmlspecialchars($review['username']);
         $reviewsHtml .= "<a href='php/recensione.php?id={$review['id']}' class='review-card'>" .

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -96,7 +96,7 @@ foreach ($topReviews as $review) {
     $stars = Utils::generateStars(round($review['avg_rating']));
     $ratingNum = number_format($review['avg_rating'], 1);
     $title = htmlspecialchars($review['product_name']);
-    $altProduct = htmlspecialchars(Utils::truncateAltText($review['product_name']));
+    $altProduct = htmlspecialchars($review['product_name']);
     $rowImg = $review['product_image'] ? "<img src='../{$review['product_image']}' alt='{$altProduct}' class='product-image'>" : '';
     $rankClass = '';
     if ($position == 1) { $rankClass = 'gold'; }

--- a/php/recensione.php
+++ b/php/recensione.php
@@ -72,7 +72,7 @@ $template = str_replace("<!--AUTHOR_PLACEHOLDER-->", htmlspecialchars($review['u
 $template = str_replace("<!--EMAIL_PLACEHOLDER-->", htmlspecialchars($review['email']), $template);
 $authorPhoto = $review['profile_photo'] ? '../' . $review['profile_photo'] : '../images/icon/user.png';
 $template = str_replace("<!--AUTHOR_PHOTO-->", $authorPhoto, $template);
-$altProduct = htmlspecialchars(Utils::truncateAltText($review['product_name']));
+$altProduct = htmlspecialchars($review['product_name']);
 $template = str_replace('alt="Immagine di <!--PRODUCT_NAME-->"', 'alt="Immagine di ' . $altProduct . '"', $template);
 $template = str_replace("<!--PRODUCT_NAME-->", htmlspecialchars($review['product_name']), $template);
 $ratingHtml = "<div class='review-rating' aria-label='Valutazione {$review['rating']} su 5'>" . Utils::generateStars($review['rating']) . "</div>";

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -96,8 +96,8 @@ if ($result !== false) {
         $stars = Utils::generateStars($review['rating']);
         $excerpt = strlen($review['content']) > 150 ? substr($review['content'], 0, 150) . '...' : $review['content'];
         $date = Utils::formatDate($review['created_at']);
-        $altProduct = Utils::truncateAltText($review['product_name']);
-        $img = $review['product_image'] ? "<img src='../{$review['product_image']}' alt='" . htmlspecialchars($altProduct) . "' class='review-image'>" : '';
+        $altProduct = htmlspecialchars($review['product_name']);
+        $img = $review['product_image'] ? "<img src='../{$review['product_image']}' alt='{$altProduct}' class='review-image'>" : '';
         $title = htmlspecialchars($review['title']);
         $user = htmlspecialchars($review['username']);
         $reviewsHtml .= "<a href='recensione.php?id={$review['id']}' class='review-card' data-rating='{$review['rating']}'>" .


### PR DESCRIPTION
## Summary
- remove `truncateAltText` calls from PHP pages

## Testing
- `grep -R "truncateAltText" -n`

------
https://chatgpt.com/codex/tasks/task_b_685ff68020a0832190450006ce83a45f