### PR TITLE
Remove terms acceptance requirement

### DIFF
--- a/js/auth-validation.js
+++ b/js/auth-validation.js
@@ -381,12 +381,6 @@ function validateRegistrationForm() {
     showSuccess('confirm-password');
   }
   
-  // Validazione accettazione termini
-  const terms = document.getElementById('terms').checked;
-  if (!terms) {
-    showError('terms', 'Devi accettare i termini e condizioni');
-    isValid = false;
-  }
   
   if (!isValid) {
     showMessage('Correggi gli errori evidenziati per continuare');

--- a/php/registrazione.php
+++ b/php/registrazione.php
@@ -45,7 +45,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = isset($_POST['username']) ? sanitizeInput($_POST['username']) : '';
     $password = isset($_POST['password']) ? $_POST['password'] : ''; // Non sanifichiamo la password
     $confirmPassword = isset($_POST['confirm-password']) ? $_POST['confirm-password'] : '';
-    $terms = isset($_POST['terms']) ? true : false;
 
     // Validazione dei dati
     if (empty($nome)) {
@@ -80,9 +79,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         redirectWithError("Le password non coincidono.");
     }
 
-    if (!$terms) {
-        redirectWithError("Devi accettare i termini e le condizioni.");
-    }
 
     // Connessione al database
     try {

--- a/php/registrazione_form.php
+++ b/php/registrazione_form.php
@@ -214,13 +214,6 @@ $header = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $he
           <div id="confirm-password-error" class="error-message" aria-live="polite"></div>
         </div>
 
-        <div class="checkbox-wrapper">
-          <input type="checkbox" id="terms" name="terms" class="checkbox-input" required aria-required="true">
-          <label for="terms" class="checkbox-label">
-            Accetto i <a href="#" target="_blank"><span>Termini e Condizioni</span></a> e la <a href="#" target="_blank"><span lang="en">Privacy Policy</span></a>
-          </label>
-          <div id="terms-error" class="error-message" aria-live="polite"></div>
-        </div>
 
         <button type="submit" class="btn btn-primary">
           Crea  <span lang="en">Account</span>


### PR DESCRIPTION
## Summary
- delete _Accetto i Termini e Condizioni e la Privacy Policy_ checkbox from the registration form
- drop related client-side validation
- drop server-side check for terms acceptance

## Testing
- `php -l php/registrazione_form.php` *(fails: command not found)*
- `npx eslint js/auth-validation.js`

------
https://chatgpt.com/codex/tasks/task_b_686003e39da083219b3ae296c7b257da