### PR TITLE
Improve accessibility features

### DIFF
--- a/static/classifiche.html
+++ b/static/classifiche.html
@@ -12,7 +12,7 @@
 <body>
   <!-- HEADER_PLACEHOLDER -->
 
-  <main id="main-content" class="main-content">
+  <main id="main-content" class="main-content" role="main">
     <!-- Hero Section -->
     <section class="rankings-hero">
       <div class="rankings-container">

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -34,7 +34,7 @@
   </aside>
 
   <!-- Main Content -->
-  <main id="main-content" class="main-content hidden">
+  <main id="main-content" class="main-content hidden" role="main">
     <div class="content-wrapper">
 
       <!-- Sezione Il mio profilo -->

--- a/static/footer.html
+++ b/static/footer.html
@@ -1,4 +1,4 @@
-<footer id="page-footer">
+<footer id="page-footer" role="contentinfo">
   <div class="footer-content">
     <div class="footer-section">
       <h3><span lang="en">ReviewDiver</span></h3>

--- a/static/gestione_recensioni.html
+++ b/static/gestione_recensioni.html
@@ -31,7 +31,7 @@
     </nav>
   </aside>
 
-  <main id="main-content" class="main-content admin-reviews">
+  <main id="main-content" class="main-content admin-reviews" role="main">
     <div class="content-wrapper">
       <section id="visualizza-section" class="content-section active">
         <div class="section-header">

--- a/static/header.html
+++ b/static/header.html
@@ -1,8 +1,8 @@
-<header>
+<header role="banner">
   <a href="#main-content" class="skip-link">Salta al contenuto principale</a>
   <a href="#site-navigation" class="skip-link">Salta al menu</a>
   <a href="#page-footer" class="skip-link">Salta al footer</a>
-  <nav id="site-navigation">
+  <nav id="site-navigation" role="navigation">
     <div class="nav-container">
       <a href="../index.php" class="logo-link" aria-label="Torna alla homepage di ReviewDiver">
         <img src="../images/logo.png" alt="Logo ReviewDiver" class="logo" />

--- a/static/index.html
+++ b/static/index.html
@@ -12,7 +12,7 @@
 <body>
   <!-- HEADER_PLACEHOLDER -->
 
-  <main id="main-content" class="main-content">
+  <main id="main-content" class="main-content" role="main">
 
     <h1 class="welcome-title">Benvenuto su <span lang="en">ReviewDiver!</span></h1>
 

--- a/static/login.html
+++ b/static/login.html
@@ -12,7 +12,7 @@
 <body>
   <!-- HEADER_PLACEHOLDER -->
   <div class="auth-page">
-    <div id="main-content" class="auth-container main-content">
+    <main id="main-content" class="auth-container main-content" role="main">
       <div class="auth-header">
         <div class="auth-logo">
           DR
@@ -21,7 +21,7 @@
         <p class="auth-subtitle">Benvenuto di nuovo! Inserisci le tue credenziali per continuare.</p>
       </div>
 
-      <div id="error-container" aria-live="polite">
+      <div id="error-container" aria-live="assertive" role="alert">
         <!-- ERROR_MESSAGE_PLACEHOLDER -->
       </div>
 
@@ -29,7 +29,7 @@
         <div class="form-group">
           <label for="username" class="form-label"><span lang="en">Username</span></label>
           <div class="form-input-wrapper">
-            <input type="text" id="username" name="username" class="form-input" placeholder="Inserisci il tuo username" autocomplete="username" required aria-required="true">
+            <input type="text" id="username" name="username" class="form-input" placeholder="Inserisci il tuo username" autocomplete="username" required aria-required="true" aria-describedby="username-error">
             <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
               <circle cx="12" cy="7" r="4"></circle>
@@ -41,7 +41,7 @@
         <div class="form-group">
           <label for="password" class="form-label"><span lang="en">Password</span></label>
           <div class="form-input-wrapper">
-            <input type="password" id="password" name="password" class="form-input" placeholder="Inserisci la tua password" autocomplete="current-password" required aria-required="true">
+            <input type="password" id="password" name="password" class="form-input" placeholder="Inserisci la tua password" autocomplete="current-password" required aria-required="true" aria-describedby="password-error">
             <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
               <circle cx="12" cy="16" r="1"></circle>
@@ -65,7 +65,7 @@
           <a href="../php/registrazione.php" class="auth-footer-link"><span>Registrati gratuitamente</span></a>
         </p>
       </div>
-    </div>
+    </main>
   </div>
   <!-- FOOTER_PLACEHOLDER -->
 </body>

--- a/static/recensione.html
+++ b/static/recensione.html
@@ -11,7 +11,7 @@
 <body>
   <!-- HEADER_PLACEHOLDER -->
 
-  <main id="main-content" class="main-content single-review">
+  <main id="main-content" class="main-content single-review" role="main">
     <div class="review-layout">
       <article class="review-detail content-box">
         <h1 class="review-title"><!--TITLE_PLACEHOLDER--></h1>

--- a/static/recensioni.html
+++ b/static/recensioni.html
@@ -12,7 +12,7 @@
 <body>
   <!-- HEADER_PLACEHOLDER -->
 
-  <main id="main-content" class="main-content">
+  <main id="main-content" class="main-content" role="main">
     <!-- Hero Section -->
     <section class="reviews-hero">
       <div class="reviews-container">

--- a/static/registrazione.html
+++ b/static/registrazione.html
@@ -12,14 +12,14 @@
 <body>
   <!-- HEADER_PLACEHOLDER -->
   <div class="auth-page">
-    <div id="main-content" class="auth-container main-content">
+    <main id="main-content" class="auth-container main-content" role="main">
       <div class="auth-header">
         <div class="auth-logo">DR</div>
         <h1 class="auth-title">Crea un nuovo <span lang="en">account</span></h1>
         <p class="auth-subtitle">Unisciti alla nostra community di food lovers!</p>
       </div>
 
-      <div id="error-container" aria-live="polite">
+      <div id="error-container" aria-live="assertive" role="alert">
         <!-- ERROR_MESSAGE_PLACEHOLDER -->
       </div>
 
@@ -28,7 +28,7 @@
           <div>
             <label for="nome" class="form-label">Nome</label>
             <div class="form-input-wrapper">
-              <input type="text" id="nome" name="nome" class="form-input" placeholder="Il tuo nome" autocomplete="given-name" required aria-required="true">
+              <input type="text" id="nome" name="nome" class="form-input" placeholder="Il tuo nome" autocomplete="given-name" required aria-required="true" aria-describedby="nome-error">
               <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
                 <circle cx="12" cy="7" r="4"></circle>
@@ -39,7 +39,7 @@
           <div>
             <label for="cognome" class="form-label">Cognome</label>
             <div class="form-input-wrapper">
-              <input type="text" id="cognome" name="cognome" class="form-input" placeholder="Il tuo cognome" autocomplete="family-name" required aria-required="true">
+              <input type="text" id="cognome" name="cognome" class="form-input" placeholder="Il tuo cognome" autocomplete="family-name" required aria-required="true" aria-describedby="cognome-error">
               <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
                 <circle cx="12" cy="7" r="4"></circle>
@@ -52,7 +52,7 @@
         <div class="form-group">
           <label for="email" class="form-label"><span lang="en">Email</span></label>
           <div class="form-input-wrapper">
-            <input type="email" id="email" name="email" class="form-input" placeholder="nome@esempio.com" autocomplete="email" required aria-required="true">
+            <input type="email" id="email" name="email" class="form-input" placeholder="nome@esempio.com" autocomplete="email" required aria-required="true" aria-describedby="email-error">
             <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
               <polyline points="22,6 12,13 2,6"></polyline>
@@ -64,7 +64,7 @@
         <div class="form-group">
           <label for="username" class="form-label"><span lang="en">Username</span></label>
           <div class="form-input-wrapper">
-            <input type="text" id="username" name="username" class="form-input" placeholder="Scegli un username unico" autocomplete="username" required aria-required="true">
+            <input type="text" id="username" name="username" class="form-input" placeholder="Scegli un username unico" autocomplete="username" required aria-required="true" aria-describedby="username-error">
             <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
               <circle cx="8.5" cy="7" r="4"></circle>
@@ -78,7 +78,7 @@
         <div class="form-group">
           <label for="password" class="form-label"><span lang="en">Password</span></label>
           <div class="form-input-wrapper">
-            <input type="password" id="password" name="password" class="form-input" placeholder="Crea una password sicura" autocomplete="new-password" required aria-required="true" aria-describedby="password-requirements" onkeyup="checkPasswordStrength()">
+            <input type="password" id="password" name="password" class="form-input" placeholder="Crea una password sicura" autocomplete="new-password" required aria-required="true" aria-describedby="password-requirements password-error" onkeyup="checkPasswordStrength()">
             <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
               <circle cx="12" cy="16" r="1"></circle>
@@ -96,7 +96,7 @@
         <div class="form-group">
           <label for="confirm-password" class="form-label">Conferma <span lang="en">Password</span></label>
           <div class="form-input-wrapper">
-            <input type="password" id="confirm-password" name="confirm-password" class="form-input" placeholder="Ripeti la password" autocomplete="new-password" required aria-required="true">
+            <input type="password" id="confirm-password" name="confirm-password" class="form-input" placeholder="Ripeti la password" autocomplete="new-password" required aria-required="true" aria-describedby="confirm-password-error">
             <svg class="form-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
               <circle cx="12" cy="16" r="1"></circle>
@@ -115,7 +115,7 @@
           <a href="login.php" class="auth-footer-link"><span>Accedi qui</span></a>
         </p>
       </div>
-    </div>
+    </main>
   </div>
   <!-- FOOTER_PLACEHOLDER -->
 </body>


### PR DESCRIPTION
## Summary
- add ARIA roles for banner, navigation and content info
- mark all main sections with `role="main"`
- convert authentication pages to `<main>` containers
- improve form accessibility with `aria-describedby`
- make login and registration alerts assertive

## Testing
- `npx eslint js`

------
https://chatgpt.com/codex/tasks/task_b_68601176f0e883218066b072a4189b2e