### PR TITLE
Fix recensioni CSS and username ownership

### DIFF
--- a/database_populate.sql
+++ b/database_populate.sql
@@ -64,19 +64,19 @@ VALUES
     (19, 16, 'Controller per PC', 'Impugnatura comoda e compatibilità perfetta.', 4, 'Controller Pro', NULL, NOW());
 
 -- Sample Comments
-INSERT INTO comments (review_id, name, email, star, content, created_at)
+INSERT INTO comments (review_id, username, email, star, content, created_at)
 VALUES
-    (1, 'Antonio', 'antonio@example.com', 5, 'Bel prodotto!', NOW()),
-    (2, 'Beatrice', 'bea@example.com', 4, 'Molto utile!', NOW()),
-    (3, 'Carlo', 'carlo@example.com', 5, 'Fantastico', NOW()),
-    (4, 'Diana', 'diana@example.com', 3, 'Non male', NOW()),
-    (5, 'Enrico', 'enrico@example.com', 4, 'Buon prodotto', NOW()),
-    (6, 'Federica', 'federica@example.com', 5, 'Lo adoro!', NOW()),
-    (7, 'Giorgio', 'giorgio@example.com', 2, 'Mi aspettavo di più', NOW()),
-    (8, 'Helena', 'helena@example.com', 4, 'Soddisfatta', NOW()),
-    (9, 'Ivan', 'ivan@example.com', 5, 'Eccellente', NOW()),
-    (10, 'Lara', 'lara@example.com', 3, 'Così così', NOW()),
-    (11, 'Mauro', 'mauro@example.com', 4, 'Buona scelta', NOW());
+    (1, 'antonio97', 'antonio@example.com', 5, 'Bel prodotto!', NOW()),
+    (2, 'bea90', 'bea@example.com', 4, 'Molto utile!', NOW()),
+    (3, 'carloUser', 'carlo@example.com', 5, 'Fantastico', NOW()),
+    (4, 'diana88', 'diana@example.com', 3, 'Non male', NOW()),
+    (5, 'enrico33', 'enrico@example.com', 4, 'Buon prodotto', NOW()),
+    (6, 'federica22', 'federica@example.com', 5, 'Lo adoro!', NOW()),
+    (7, 'giorgio7', 'giorgio@example.com', 2, 'Mi aspettavo di più', NOW()),
+    (8, 'helena9', 'helena@example.com', 4, 'Soddisfatta', NOW()),
+    (9, 'ivan_iv', 'ivan@example.com', 5, 'Eccellente', NOW()),
+    (10, 'lara_the_best', 'lara@example.com', 3, 'Così così', NOW()),
+    (11, 'mauro75', 'mauro@example.com', 4, 'Buona scelta', NOW());
 
 -- Confirmation message
 SELECT 'Database populated successfully with sample data.' AS message;

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -49,12 +49,12 @@ CREATE TABLE reviews (
 CREATE TABLE comments (
     id INT AUTO_INCREMENT PRIMARY KEY,
     review_id INT NOT NULL,
-    name VARCHAR(100) NOT NULL,
+    username VARCHAR(50) NOT NULL,
     email VARCHAR(100) NOT NULL,
     star TINYINT NOT NULL DEFAULT 1,
     content TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY unique_comment (review_id, email),
+    UNIQUE KEY unique_comment (review_id, username),
     FOREIGN KEY (review_id) REFERENCES reviews(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/php/api.php
+++ b/php/api.php
@@ -398,11 +398,11 @@ function handle_comments($commentManager) {
                 $reviewId = (int)($_POST['review_id'] ?? 0);
                 $star = min(5, max(1, intval($_POST['star'] ?? 1)));
                 $content = Utils::sanitizeInput($_POST['content'] ?? '');
-                $name = $_SESSION['user_data']['username'] ?? '';
+                $username = $_SESSION['user_data']['username'] ?? '';
                 $email = $_SESSION['user_data']['email'] ?? '';
 
-                if ($reviewId && $name && $email && $content) {
-                    if ($commentManager->createComment($reviewId, $name, $email, $star, $content)) {
+                if ($reviewId && $username && $content) {
+                    if ($commentManager->createComment($reviewId, $username, $email, $star, $content)) {
                         echo json_encode(['success' => true]);
                     } else {
                         http_response_code(500);
@@ -435,8 +435,8 @@ function handle_comments($commentManager) {
 }
 
 function handle_user_comments($commentManager) {
-    $email = $_SESSION['user_data']['email'] ?? '';
-    if (!$email) {
+    $username = $_SESSION['user_data']['username'] ?? '';
+    if (!$username) {
         http_response_code(401);
         echo json_encode(['success' => false, 'message' => 'Utente non autenticato']);
         return;
@@ -458,7 +458,7 @@ function handle_user_comments($commentManager) {
                     'date_filter' => Utils::sanitizeInput($_GET['date_filter'] ?? '')
                 ];
                 $filters = array_filter($filters);
-                $result = $commentManager->getUserComments($email, $page, $limit, $filters);
+                $result = $commentManager->getUserComments($username, $page, $limit, $filters);
                 if ($result !== false) {
                     foreach ($result['comments'] as &$comment) {
                         $comment['formatted_date'] = Utils::formatDate($comment['created_at']);
@@ -484,7 +484,7 @@ function handle_user_comments($commentManager) {
                     'star' => (int)($_POST['star'] ?? 1),
                     'content' => Utils::sanitizeInput($_POST['content'] ?? '')
                 ];
-                $updated = $commentManager->updateComment($commentId, $data, $email);
+                $updated = $commentManager->updateComment($commentId, $data, $username);
                 if ($updated) {
                     echo json_encode(['success' => true, 'message' => 'Commento aggiornato con successo']);
                 } else {
@@ -499,7 +499,7 @@ function handle_user_comments($commentManager) {
                     echo json_encode(['success' => false, 'message' => 'ID commento mancante']);
                     break;
                 }
-                $deleted = $commentManager->deleteComment($commentId, $email);
+                $deleted = $commentManager->deleteComment($commentId, $username);
                 if ($deleted) {
                     echo json_encode(['success' => true, 'message' => 'Commento eliminato con successo']);
                 } else {

--- a/php/database.php
+++ b/php/database.php
@@ -444,18 +444,18 @@ class CommentManager {
     /**
      * Crea un nuovo commento
      */
-    public function createComment($reviewId, $name, $email, $star, $content) {
+    public function createComment($reviewId, $username, $email, $star, $content) {
         try {
             // Verifica se esiste già un commento dello stesso utente per la stessa recensione
-            $check = $this->db->prepare("SELECT id FROM comments WHERE review_id = ? AND email = ?");
-            $check->execute([$reviewId, $email]);
+            $check = $this->db->prepare("SELECT id FROM comments WHERE review_id = ? AND username = ?");
+            $check->execute([$reviewId, $username]);
             if ($existing = $check->fetch()) {
                 $stmt = $this->db->prepare("UPDATE comments SET star = ?, content = ?, created_at = NOW() WHERE id = ?");
                 return $stmt->execute([$star, $content, $existing['id']]);
             }
 
-            $stmt = $this->db->prepare("INSERT INTO comments (review_id, name, email, star, content, created_at) VALUES (?, ?, ?, ?, ?, NOW())");
-            return $stmt->execute([$reviewId, $name, $email, $star, $content]);
+            $stmt = $this->db->prepare("INSERT INTO comments (review_id, username, email, star, content, created_at) VALUES (?, ?, ?, ?, ?, NOW())");
+            return $stmt->execute([$reviewId, $username, $email, $star, $content]);
         } catch (PDOException $e) {
             error_log('Errore createComment: ' . $e->getMessage());
             return false;
@@ -467,7 +467,7 @@ class CommentManager {
      */
     public function getComments($reviewId, $limit = null) {
         try {
-            $sql = "SELECT name, email, star, content, created_at FROM comments WHERE review_id = ? ORDER BY created_at DESC";
+            $sql = "SELECT username, email, star, content, created_at FROM comments WHERE review_id = ? ORDER BY created_at DESC";
             if ($limit) {
                 $sql .= " LIMIT " . intval($limit);
             }
@@ -483,10 +483,10 @@ class CommentManager {
     /**
      * Ottiene il commento di un utente per una specifica recensione
      */
-    public function getUserCommentForReview($reviewId, $email) {
+    public function getUserCommentForReview($reviewId, $username) {
         try {
-            $stmt = $this->db->prepare("SELECT id, star, content, created_at FROM comments WHERE review_id = ? AND email = ?");
-            $stmt->execute([$reviewId, $email]);
+            $stmt = $this->db->prepare("SELECT id, star, content, created_at FROM comments WHERE review_id = ? AND username = ?");
+            $stmt->execute([$reviewId, $username]);
             return $stmt->fetch();
         } catch (PDOException $e) {
             error_log('Errore getUserCommentForReview: ' . $e->getMessage());
@@ -497,12 +497,12 @@ class CommentManager {
     /**
      * Ottiene i commenti di un utente con paginazione e filtri
      */
-    public function getUserComments($email, $page = 1, $limit = 10, $filters = []) {
+    public function getUserComments($username, $page = 1, $limit = 10, $filters = []) {
         try {
             $offset = ($page - 1) * $limit;
 
-            $where = ["c.email = ?"];
-            $params = [$email];
+            $where = ["c.username = ?"];
+            $params = [$username];
 
             if (!empty($filters['search'])) {
                 $where[] = "(LOWER(c.content) LIKE LOWER(?) OR LOWER(r.title) LIKE LOWER(?))";
@@ -570,14 +570,14 @@ class CommentManager {
     /**
      * Aggiorna un commento
      */
-    public function updateComment($commentId, $data, $email = null) {
+    public function updateComment($commentId, $data, $username = null) {
         try {
-            if ($email === null) {
+            if ($username === null) {
                 $stmt = $this->db->prepare("UPDATE comments SET star = ?, content = ? WHERE id = ?");
                 return $stmt->execute([$data['star'], $data['content'], $commentId]);
             }
-            $stmt = $this->db->prepare("UPDATE comments SET star = ?, content = ? WHERE id = ? AND email = ?");
-            $stmt->execute([$data['star'], $data['content'], $commentId, $email]);
+            $stmt = $this->db->prepare("UPDATE comments SET star = ?, content = ? WHERE id = ? AND username = ?");
+            $stmt->execute([$data['star'], $data['content'], $commentId, $username]);
             return $stmt->rowCount() > 0;
         } catch (PDOException $e) {
             error_log('Errore updateComment: ' . $e->getMessage());
@@ -588,14 +588,14 @@ class CommentManager {
     /**
      * Elimina un commento
      */
-    public function deleteComment($commentId, $email = null) {
+    public function deleteComment($commentId, $username = null) {
         try {
-            if ($email === null) {
+            if ($username === null) {
                 $stmt = $this->db->prepare("DELETE FROM comments WHERE id = ?");
                 $stmt->execute([$commentId]);
             } else {
-                $stmt = $this->db->prepare("DELETE FROM comments WHERE id = ? AND email = ?");
-                $stmt->execute([$commentId, $email]);
+                $stmt = $this->db->prepare("DELETE FROM comments WHERE id = ? AND username = ?");
+                $stmt->execute([$commentId, $username]);
             }
             return $stmt->rowCount() > 0;
         } catch (PDOException $e) {

--- a/php/recensione.php
+++ b/php/recensione.php
@@ -27,9 +27,10 @@ $reviewManager = new ReviewManager();
 $commentManager = new CommentManager();
 $userComment = null;
 if (SessionManager::isLoggedIn()) {
+    $username = $_SESSION['user_data']['username'] ?? '';
     $email = $_SESSION['user_data']['email'] ?? '';
-    if ($email) {
-        $userComment = $commentManager->getUserCommentForReview($reviewId, $email);
+    if ($username) {
+        $userComment = $commentManager->getUserCommentForReview($reviewId, $username);
     }
 }
 $review = $reviewManager->getReviewById($reviewId);
@@ -111,7 +112,7 @@ $commentsHtml = '';
 foreach ($comments as $c) {
     $date = Utils::formatDate($c['created_at']);
     $stars = Utils::generateStars($c['star']);
-    $commentsHtml .= "<div class='comment'><div class='comment-author'>".htmlspecialchars($c['name'])."</div>".
+    $commentsHtml .= "<div class='comment'><div class='comment-author'>".htmlspecialchars($c['username'])."</div>".
                      "<div class='comment-email'>".htmlspecialchars($c['email'])."</div>".
                      "<div class='comment-rating' aria-label='Valutazione {$c['star']} su 5'>{$stars}</div>".
                      "<p class='comment-content'>".htmlspecialchars($c['content'])."</p>".

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -31,6 +31,10 @@ $footer = file_get_contents("../static/footer.html");
 
 // Caricamento del template HTML
 $DOM = file_get_contents("../static/recensioni.html");
+// Correzione del percorso dei fogli di stile in base alla posizione dello script
+$cssBase = dirname($_SERVER['PHP_SELF']) === '/' ? 'css/' : '../css/';
+$DOM = str_replace("../css/style.css", $cssBase . 'style.css', $DOM);
+$DOM = str_replace("../css/pages.css", $cssBase . 'pages.css', $DOM);
 // Inserimento header e footer
 $DOM = str_replace("<!-- HEADER_PLACEHOLDER -->", $header, $DOM);
 $DOM = str_replace("<!-- FOOTER_PLACEHOLDER -->", $footer, $DOM);


### PR DESCRIPTION
## Summary
- adjust stylesheet path for the recensioni page
- check comment ownership using only the username
- update comments table to store username
- revise schema and populate scripts

## Testing
- ❌ `php -l php/api.php` (failed to run: `php: command not found`)
- ❌ `php -l php/database.php` (failed to run: `php: command not found`)
- ❌ `php -l php/recensione.php` (failed to run: `php: command not found`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6860145df3908321b215a8bc66b93d0e