### PR TITLE
Style blocks on recensione detail page

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -557,3 +557,12 @@
     margin-top: var(--spacing-lg);
   }
 }
+
+/* Sezioni in stile dashboard */
+.profile-info-section {
+  background: var(--surface);
+  padding: var(--spacing-xl);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  border: 0.0625rem solid var(--border);
+}

--- a/static/recensione.html
+++ b/static/recensione.html
@@ -13,7 +13,7 @@
 
   <main id="main-content" class="main-content single-review" role="main">
     <div class="review-layout">
-      <article class="review-detail content-box">
+      <article class="review-detail profile-info-section">
         <h1 class="review-title"><!--TITLE_PLACEHOLDER--></h1>
         <!--RATING_HTML-->
         <div class="review-meta">
@@ -24,19 +24,19 @@
         <div class="review-text"><!--CONTENT_PLACEHOLDER--></div>
       </article>
 
-      <aside class="author-info content-box">
+      <aside class="author-info profile-info-section">
         <img src="<!--AUTHOR_PHOTO-->" alt="Foto profilo di <!--AUTHOR_PLACEHOLDER-->" class="profile-photo">
         <p class="author-name">Autore: <span><!--AUTHOR_PLACEHOLDER--></span></p>
         <p class="author-email"><!--EMAIL_PLACEHOLDER--></p>
       </aside>
     </div>
 
-    <section class="comment-list content-box" aria-labelledby="commenti-title">
+    <section class="comment-list profile-info-section" aria-labelledby="commenti-title">
       <h2 id="commenti-title">Commenti</h2>
       <!--COMMENTS_PLACEHOLDER-->
     </section>
 
-    <section class="comments-section content-box" aria-labelledby="opinione-title">
+    <section class="comments-section profile-info-section" aria-labelledby="opinione-title">
       <h2 id="opinione-title">Lascia un tuo opinione</h2>
       <div id="user-comment-info"></div>
       <form id="comment-form" method="post" class="comment-form">


### PR DESCRIPTION
## Summary
- update recensione detail page to use the `profile-info-section` look
- add matching style in `pages.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686022c57040832193680199c5a29548