### PR TITLE
Fix profile section layout

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -293,7 +293,7 @@ body {
 .profile-name-section {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   flex: 1;
   margin-right: var(--spacing-md);
 }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -50,7 +50,6 @@
               <div class="profile-basic-info">
                 <div class="profile-header">
                   <div class="profile-name-section">
-                    <h2 class="profile-name" id="profileDisplayName"></h2>
                     <div class="basic-fields">
                       <div class="form-group">
                         <label for="lastName">Cognome*</label>


### PR DESCRIPTION
## Summary
- remove profile display name from dashboard page
- adjust layout so profile photo aligns with basic fields

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68603588ced083218a4c2c3c5d32904c