### PR TITLE
Fix rating table layout

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -397,7 +397,7 @@
   color: var(--text-secondary);
 }
 
-.rating-display {
+.rating-display .rating-container {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -106,7 +106,7 @@ foreach ($topReviews as $review) {
     $rowsHtml .= "<tr class='ranking-row' tabindex='0' role='link' data-review-id='{$review['review_id']}' aria-label='Dettagli {$title}'>".
                  "<td class='rank-position {$rankClass}'>{$position}</td>".
                  "<td class='product-info'>{$rowImg}<div class='product-details'><p class='product-title'>{$title}</p></div></td>".
-                 "<td class='rating-display'><span class='rating-number'>{$ratingNum}</span><div class='rating-stars'>{$stars}</div></td>".
+                 "<td class='rating-display'><div class='rating-container'><span class='rating-number'>{$ratingNum}</span><div class='rating-stars'>{$stars}</div></div></td>".
                  "</tr>";
 
     $position++;


### PR DESCRIPTION
## Summary
- keep `<td>` as table cell in PHP table rendering
- move flex styling to internal element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68604975af1483219977c16b8c4bd9ca