### PR TITLE
Show numeric rating on recensioni page

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -611,11 +611,13 @@ body {
   display: flex;
   gap: 0.125rem;
   margin-bottom: var(--spacing-xs);
+  font-weight: 600;
 }
 
 .star {
   color: #FFD700;
   font-size: 1rem;
+  font-weight: normal;
 }
 
 .star.empty {

--- a/css/pages.css
+++ b/css/pages.css
@@ -123,11 +123,13 @@
   display: flex;
   gap: 0.125rem;
   margin-left: var(--spacing-sm);
+  font-weight: 600;
 }
 
 .star {
   color: #FFD700;
   font-size: 1.1rem;
+  font-weight: normal;
 }
 
 .star.empty {

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -99,7 +99,7 @@ $reviewsHtml = '';
 if ($result !== false) {
     foreach ($result['reviews'] as $review) {
         $avgRating = $commentManager->getAverageRatingForProduct($review['product_name']);
-        $stars = Utils::generateStars($review['rating']);
+        $ratingText = htmlspecialchars($review['rating']) . "/5";
         $excerpt = strlen($review['content']) > 150 ? substr($review['content'], 0, 150) . '...' : $review['content'];
         $date = Utils::formatDate($review['created_at']);
         $altProduct = htmlspecialchars($review['product_name']);
@@ -109,7 +109,7 @@ if ($result !== false) {
         $reviewsHtml .= "<a href='recensione.php?id={$review['id']}' class='review-card' data-rating='{$avgRating}'>" .
                         "<div class='review-content'>" .
                         "<div class='review-header'><h3 class='review-title'>{$title}</h3>" .
-                        "<div class='review-rating' aria-label='Valutazione {$review['rating']} su 5'>{$stars}</div></div>" .
+                        "<div class='review-rating' aria-label='Valutazione {$review['rating']} su 5'>{$ratingText}</div></div>" .
                         $img .
                         "<div class='review-meta'><span class='review-author'>{$user}</span><span>•</span><span class='review-date'>{$date}</span></div>" .
                         "<p class='review-excerpt'>" . htmlspecialchars($excerpt) . "</p>" .


### PR DESCRIPTION
## Summary
- display numeric rating on the recensioni listing instead of star icons
- style review rating text

## Testing
- `php -l php/recensioni.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68604a77e7a08321b163aae9a88808ca