### PR TITLE
Remove dashboard loader and add animation

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -319,6 +319,7 @@ body {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
   border: 0.0625rem solid var(--border);
+  animation: fade-in 0.3s ease-in-out;
 }
 
 /* Form Styles */
@@ -946,28 +947,6 @@ input:checked + .toggle-slider::before {
 
 .overlay.active {
   display: block;
-}
-
-/* Overlay di caricamento */
-.loading-overlay {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  /* Overlay completamente opaco per nascondere i contenuti sottostanti */
-  background: rgb(0 0 0);
-  color: var(--text-light);
-  font-size: 1.25rem;
-  font-weight: 600;
-  z-index: 999;
-  align-items: center;
-  justify-content: center;
-}
-
-.loading-overlay.active {
-  display: flex;
 }
 
 /* Indicatori di caricamento nelle liste */

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -11,25 +11,6 @@ class DashboardManager {
         this.init();
     }
 
-    /**
-     * Mostra la schermata di caricamento
-     */
-    showLoading() {
-        const loader = document.getElementById('loadingOverlay');
-        if (loader) {
-            loader.classList.add('active');
-        }
-    }
-
-    /**
-     * Nasconde la schermata di caricamento
-     */
-    hideLoading() {
-        const loader = document.getElementById('loadingOverlay');
-        if (loader) {
-            loader.classList.remove('active');
-        }
-    }
     showPage() {
         document.getElementById("sidebar")?.classList.remove("hidden");
         document.getElementById("main-content")?.classList.remove("hidden");
@@ -293,7 +274,6 @@ class DashboardManager {
      * Carica dati utente
      */
     async loadUserData() {
-        this.showLoading();
         try {
             const data = await this.safeFetchJson('api.php?endpoint=profile');
 
@@ -306,8 +286,6 @@ class DashboardManager {
         } catch (error) {
             console.error('Errore caricamento dati utente:', error);
             this.showNotification('Errore di connessione', 'error');
-        } finally {
-            this.hideLoading();
         }
     }
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -272,8 +272,6 @@
 
   <!-- Overlay per mobile -->
   <div class="overlay" id="overlay"></div>
-  <!-- Overlay di caricamento -->
-  <div class="loading-overlay active" id="loadingOverlay" role="status" aria-live="polite">Caricamento in corso...</div>
 
   <!-- FOOTER_PLACEHOLDER -->
 


### PR DESCRIPTION
## Summary
- drop loading overlay from dashboard
- delete JS methods for showing the loader
- remove corresponding CSS
- animate the profile info section when displayed

## Testing
- `npx eslint js/dashboard.js` *(fails: command not found or network restriction)*

------
https://chatgpt.com/codex/tasks/task_b_686066d9da108321ad3eff170913cf16