### PR TITLE
Add profile loading indicator

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -24,6 +24,8 @@ class DashboardManager {
     async init() {
         this.setupEventListeners();
         this.setupSidebar();
+        this.showPage();
+        this.toggleProfileLoading(true);
         await this.loadUserData();
         this.setupFormValidation();
         this.setupDateSelectors();
@@ -270,6 +272,23 @@ class DashboardManager {
         throw new Error(text);
     }
 
+    toggleProfileLoading(show) {
+        const container = document.getElementById('profileContainer');
+        const dangerZone = document.getElementById('dangerZone');
+        const loading = document.getElementById('profileLoading');
+        if (container && loading) {
+            if (show) {
+                container.classList.add('hidden');
+                if (dangerZone) dangerZone.classList.add('hidden');
+                loading.classList.remove('hidden');
+            } else {
+                container.classList.remove('hidden');
+                if (dangerZone) dangerZone.classList.remove('hidden');
+                loading.classList.add('hidden');
+            }
+        }
+    }
+
     /**
      * Carica dati utente
      */
@@ -279,13 +298,14 @@ class DashboardManager {
 
             if (data.success) {
                 this.populateUserData(data.data);
-                this.showPage();
             } else {
                 this.showNotification('Errore nel caricamento dei dati utente', 'error');
             }
+            this.toggleProfileLoading(false);
         } catch (error) {
             console.error('Errore caricamento dati utente:', error);
             this.showNotification('Errore di connessione', 'error');
+            this.toggleProfileLoading(false);
         }
     }
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -44,7 +44,10 @@
           <h1>Il mio profilo</h1>
           <p>Gestisci le informazioni del tuo account</p>
         </div>
-        <div class="profile-container">
+        <div id="profileLoading" class="list-loading" role="status" aria-live="polite">
+          <span class="spinner" aria-hidden="true"></span> Caricamento profilo...
+        </div>
+        <div class="profile-container hidden" id="profileContainer">
           <!-- Informazioni profilo -->
           <div class="profile-info-section">
             <form class="profile-form" id="profileForm">
@@ -117,7 +120,7 @@
         </div>
 
         <!-- Sezione pericolosa -->
-        <div class="danger-zone">
+        <div class="danger-zone hidden" id="dangerZone">
           <h3>Zona pericolosa</h3>
           <p>Le azioni seguenti sono irreversibili. Procedi con cautela.</p>
           <button class="btn btn-danger" id="deleteAccountBtn">


### PR DESCRIPTION
## Summary
- show sidebar and page layout immediately
- display a spinner while user profile data loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6860dc9b7f848321bc0478f136da948c