### PR TITLE
Remove ranking images and colors

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -363,29 +363,12 @@
   text-align: center;
 }
 
-.rank-position.gold {
-  color: #FFD700;
-}
-
-.rank-position.silver {
-  color: #C0C0C0;
-}
-
-.rank-position.bronze {
-  color: #CD7F32;
-}
 
 .product-info {
   align-items: center;
   gap: var(--spacing-md);
 }
 
-.product-image {
-  width: 3.75rem;
-  height: 3.75rem;
-  object-fit: cover;
-  border-radius: var(--radius-sm);
-}
 
 .product-details h4 {
   margin: 0 0 0.25rem;

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -96,16 +96,10 @@ foreach ($topReviews as $review) {
     $stars = Utils::generateStars(round($review['avg_rating']));
     $ratingNum = number_format($review['avg_rating'], 1);
     $title = htmlspecialchars($review['product_name']);
-    $altProduct = htmlspecialchars($review['product_name']);
-    $rowImg = $review['product_image'] ? "<img src='../{$review['product_image']}' alt='{$altProduct}' class='product-image'>" : '';
-    $rankClass = '';
-    if ($position == 1) { $rankClass = 'gold'; }
-    elseif ($position == 2) { $rankClass = 'silver'; }
-    elseif ($position == 3) { $rankClass = 'bronze'; }
 
     $rowsHtml .= "<tr class='ranking-row' tabindex='0' role='link' data-review-id='{$review['review_id']}' aria-label='Dettagli {$title}'>".
-                 "<td class='rank-position {$rankClass}' data-label='Pos.'>{$position}</td>".
-                 "<td class='product-info' data-label='Prodotto'>{$rowImg}<div class='product-details'><p class='product-title'>{$title}</p></div></td>".
+                 "<td class='rank-position' data-label='Pos.'>{$position}</td>".
+                 "<td class='product-info' data-label='Prodotto'><p class='product-title'>{$title}</p></td>".
                  "<td class='rating-display' data-label='Valutazione'><div class='rating-container'><span class='rating-number'>{$ratingNum}</span><div class='rating-stars'>{$stars}</div></div></td>".
                  "</tr>";
 


### PR DESCRIPTION
## Summary
- simplify ranking rows
- drop special colors for ranks and remove product images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6860e32172b88321be2a277c1f8b6933