### PR TITLE
Modify review card hover behavior and button label

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -90,6 +90,11 @@
 }
 
 .review-card:hover {
+  transform: none;
+  box-shadow: var(--shadow-md);
+}
+
+.review-card:has(.view-btn:hover) {
   transform: translateY(-0.25rem);
   box-shadow: var(--shadow-lg);
 }

--- a/js/gestione_recensioni.js
+++ b/js/gestione_recensioni.js
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 <span class="review-date">${escapeHtml(r.formatted_date)}</span>
               </div>
               <div class="review-actions">
-                <a href="recensione.php?id=${r.id}" class="view-btn">Visualizza</a>
+                <a href="recensione.php?id=${r.id}" class="view-btn">Dettagli</a>
                 <button class="delete-btn" data-id="${r.id}">Elimina</button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- keep review cards static on hover
- raise review cards when hovering the details button
- rename the review button text from "Visualizza" to "Dettagli"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6860ee07ae7483219dcbdcc44ef8989d