### PR TITLE
Prevent underline on rating stars

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -619,6 +619,7 @@ body {
   color: #FFD700;
   font-size: 1rem;
   font-weight: normal;
+  text-decoration: none;
 }
 
 .star.empty {

--- a/css/pages.css
+++ b/css/pages.css
@@ -150,6 +150,7 @@
   color: #FFD700;
   font-size: 1.1rem;
   font-weight: normal;
+  text-decoration: none;
 }
 
 .star.empty {


### PR DESCRIPTION
## Summary
- ensure star icons aren't underlined on hover

## Testing
- `grep -n "text-decoration" css/pages.css`
- `grep -n "text-decoration" css/dashboard.css`


------
https://chatgpt.com/codex/tasks/task_b_6860fe9ff0c88321b0d0dcdeed58f6d7