### PR TITLE
Remove secure and httponly settings

### DIFF
--- a/php/login.php
+++ b/php/login.php
@@ -16,8 +16,6 @@ require_once 'database.php';
 session_set_cookie_params([
     'lifetime' => 3600,           // Durata del cookie di sessione (1 ora)
     'path' => '/',                // Percorso del cookie
-    'secure' => true,             // Cookie inviato solo su HTTPS
-    'httponly' => true            // Cookie non accessibile via JavaScript
 ]);
 SessionManager::start();
 

--- a/php/logout.php
+++ b/php/logout.php
@@ -44,8 +44,7 @@ if (isset($_SESSION['is_logged_in']) && $_SESSION['is_logged_in'] === true) {
     if (ini_get("session.use_cookies")) {
         $params = session_get_cookie_params();
         setcookie(session_name(), '', time() - 42000,
-            $params["path"], $params["domain"],
-            $params["secure"], $params["httponly"]
+            $params["path"], $params["domain"]
         );
     }
 

--- a/php/registrazione.php
+++ b/php/registrazione.php
@@ -13,8 +13,6 @@
 session_set_cookie_params([
     'lifetime' => 3600,           // Durata del cookie di sessione (1 ora)
     'path' => '/',                // Percorso del cookie
-    'secure' => true,             // Cookie inviato solo su HTTPS
-    'httponly' => true            // Cookie non accessibile via JavaScript
 ]);
 session_start();
 


### PR DESCRIPTION
## Summary
- remove `secure` and `httponly` parameters from `session_set_cookie_params`
- adjust logout routine to stop relying on removed params

## Testing
- `php -l php/login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686106332c948321bd6c529019e673d0