### PR TITLE
Remove comment date filter

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -162,16 +162,12 @@ class DashboardManager {
         // Ricerca e filtri commenti
         const commentSearch = document.getElementById('commentSearch');
         const commentRatingFilter = document.getElementById('commentRatingFilter');
-        const commentDateFilter = document.getElementById('commentDateFilter');
 
         if (commentSearch) {
             commentSearch.addEventListener('input', this.debounce(() => this.loadComments(), 500));
         }
         if (commentRatingFilter) {
             commentRatingFilter.addEventListener('change', () => this.loadComments());
-        }
-        if (commentDateFilter) {
-            commentDateFilter.addEventListener('change', () => this.loadComments());
         }
 
 
@@ -530,7 +526,6 @@ class DashboardManager {
     async loadComments(page = 1) {
         const search = document.getElementById('commentSearch')?.value || '';
         const rating = document.getElementById('commentRatingFilter')?.value || '';
-        const commentDateFilter = document.getElementById('commentDateFilter')?.value || '';
 
         const commentsList = document.getElementById('commentsList');
         const pagination = document.getElementById('commentsPagination');
@@ -546,8 +541,7 @@ class DashboardManager {
             page: page,
             limit: this.commentsPerPage,
             search: search,
-            rating: rating,
-            date_filter: commentDateFilter
+            rating: rating
         });
 
         try {

--- a/php/api.php
+++ b/php/api.php
@@ -212,8 +212,7 @@ function handle_reviews($userId, $reviewManager) {
                 $limit = (int)($_GET['limit'] ?? 10);
                 $filters = [
                     'search' => Utils::sanitizeInput($_GET['search'] ?? ''),
-                    'rating' => (int)($_GET['rating'] ?? 0),
-                    'date_filter' => Utils::sanitizeInput($_GET['date_filter'] ?? '')
+                    'rating' => (int)($_GET['rating'] ?? 0)
                 ];
                 $filters = array_filter($filters);
                 if ($isAdmin && isset($_GET['all'])) {
@@ -455,7 +454,6 @@ function handle_user_comments($commentManager) {
                 $filters = [
                     'search' => Utils::sanitizeInput($_GET['search'] ?? ''),
                     'rating' => (int)($_GET['rating'] ?? 0),
-                    'date_filter' => Utils::sanitizeInput($_GET['date_filter'] ?? '')
                 ];
                 $filters = array_filter($filters);
                 $result = $commentManager->getUserComments($username, $page, $limit, $filters);

--- a/php/database.php
+++ b/php/database.php
@@ -486,20 +486,6 @@ class CommentManager {
                 $params[] = $filters['rating'];
             }
 
-            if (!empty($filters['date_filter'])) {
-                switch ($filters['date_filter']) {
-                    case 'week':
-                        $where[] = "c.created_at >= DATE_SUB(NOW(), INTERVAL 1 WEEK)";
-                        break;
-                    case 'month':
-                        $where[] = "c.created_at >= DATE_SUB(NOW(), INTERVAL 1 MONTH)";
-                        break;
-                    case 'year':
-                        $where[] = "c.created_at >= DATE_SUB(NOW(), INTERVAL 1 YEAR)";
-                        break;
-                }
-            }
-
             $whereClause = implode(' AND ', $where);
 
             $stmt = $this->db->prepare(

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -154,12 +154,6 @@
                 <option value="2">2 stelle</option>
                 <option value="1">1 stella</option>
               </select>
-              <select id="commentDateFilter">
-                <option value="">Tutte le date</option>
-                <option value="week">Ultima settimana</option>
-                <option value="month">Ultimo mese</option>
-                <option value="year">Ultimo anno</option>
-              </select>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- drop date filter dropdown from the "I miei commenti" section
- remove all JS handling of `commentDateFilter`
- update API handler and database query to no longer filter comments by date

## Testing
- `npx eslint js/dashboard.js` *(fails: Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_b_68610c8608908321a5c49979275c66e3