### PR TITLE
Fix PHP syntax issues

### DIFF
--- a/php/database.php
+++ b/php/database.php
@@ -34,6 +34,8 @@ class DatabaseConfig {
         }
     }
 
+}
+
 /**
  * Classe per la gestione degli utenti
  */
@@ -813,9 +815,9 @@ class Utils {
  * Gestione delle sessioni
  */
 class SessionManager {
-    public static function ratingt() {
+    public static function start() {
         if (session_status() === PHP_SESSION_NONE) {
-            session_ratingt();
+            session_start();
         }
     }
 


### PR DESCRIPTION
## Summary
- close `DatabaseConfig` class properly
- implement `SessionManager::start()` using `session_start`

## Testing
- `php -l php/database.php`
- `php -l php/*.php`
- `npx eslint js/*.js`

------
https://chatgpt.com/codex/tasks/task_b_6861119ffe5c83218721073a1edf921e