### PR TITLE
Fix pagination on Recensioni

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -108,6 +108,11 @@ document.addEventListener('DOMContentLoaded', function() {
     const noReviews = document.getElementById('no-reviews');
     const reviewsPerPage = 20;
     let reviewsPage = 1;
+    const urlParams = new URLSearchParams(window.location.search);
+    const initialPage = parseInt(urlParams.get('page'), 10);
+    if (!isNaN(initialPage) && initialPage > 1) {
+      reviewsPage = initialPage;
+    }
     let currentReviews = [];
 
     function escapeHtml(text) {
@@ -118,6 +123,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     async function loadReviews(page = 1) {
       reviewsPage = page;
+      history.replaceState(null, '', `?page=${page}`);
       if (reviewsGrid) {
         reviewsGrid.innerHTML = `\n        <div class="list-loading" role="status" aria-live="polite">\n          <span class="spinner" aria-hidden="true"></span> Caricamento in corso...\n        </div>`;
       }
@@ -213,7 +219,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (searchFilter) searchFilter.addEventListener('input', displayReviews);
     if (sortFilter) sortFilter.addEventListener('change', displayReviews);
 
-    loadReviews();
+    loadReviews(reviewsPage);
   }
 
   // Disable navigation link for the current page


### PR DESCRIPTION
## Summary
- parse the `page` query parameter when Recensioni loads
- keep the page in the URL while paginating

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_b_686125e3a61883218a6c0e3125bd66fe