### PR TITLE
Fix query error on review detail page

### DIFF
--- a/php/database.php
+++ b/php/database.php
@@ -356,7 +356,8 @@ class ReviewManager {
                 "FROM reviews r " .
                 "JOIN utenti u ON r.user_id = u.id " .
                 "LEFT JOIN comments c ON r.id = c.review_id " .
-                "WHERE r.id = ? AND r.deleted_at IS NULL"
+                "WHERE r.id = ? AND r.deleted_at IS NULL " .
+                "GROUP BY r.id"
             );
             $stmt->execute([$reviewId]);
             return $stmt->fetch();


### PR DESCRIPTION
## Summary
- add missing `GROUP BY` clause in `getReviewById` query to avoid SQL errors

## Testing
- `php -l php/database.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686154c32ce8832190a316e90092743e