### PR TITLE
Fix classification warnings

### DIFF
--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -93,8 +93,9 @@ $topReviews = $reviewManager->getTopProducts(10);
 $rowsHtml = '';
 $position = 1;
 foreach ($topReviews as $review) {
-    $stars = Utils::generateStars(round($review['avg_rating']));
-    $ratingNum = number_format($review['avg_rating'], 1);
+    $avgRating = $review['avg_rating'] ?? 0;
+    $stars = Utils::generateStars(round($avgRating));
+    $ratingNum = number_format($avgRating, 1);
     $title = htmlspecialchars($review['product_name']);
 
     $rowsHtml .= "<tr class='ranking-row' tabindex='0' role='link' data-review-id='{$review['review_id']}' aria-label='Dettagli {$title}'>".

--- a/php/database.php
+++ b/php/database.php
@@ -387,7 +387,7 @@ class ReviewManager {
         try {
             $stmt = $this->db->prepare(
                 "SELECT r.product_name, r.product_image, " .
-                "AVG(c.rating) AS avg_rating, COUNT(c.id) AS review_count, " .
+                "COALESCE(AVG(c.rating), 0) AS avg_rating, COUNT(c.id) AS review_count, " .
                 "MIN(r.id) AS review_id " .
                 "FROM reviews r " .
                 "LEFT JOIN comments c ON r.id = c.review_id " .


### PR DESCRIPTION
## Summary
- avoid null avg_rating in classifiche
- ensure database returns 0 rating when there are no comments

## Testing
- `php -l php/database.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6861694d180c83219e6dac8e53e2ad05