### PR TITLE
Fix user menu without JS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -295,7 +295,15 @@ textarea:focus,
 /* User Menu Dropdown Styles */
 .user-menu {
   position: relative;
+}
+
+.user-menu > summary {
+  list-style: none;
   cursor: pointer;
+}
+
+.user-menu > summary::-webkit-details-marker {
+  display: none;
 }
 
 .user-menu-panel {
@@ -314,7 +322,7 @@ textarea:focus,
   transition: var(--transition);
 }
 
-.user-menu-panel.open {
+.user-menu[open] > .user-menu-panel {
   opacity: 1;
   visibility: visible;
   transform: translateX(0);

--- a/index.php
+++ b/index.php
@@ -74,12 +74,14 @@ if (!SessionManager::isLoggedIn()) {
   $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
 
   $headerLoginHtml = "
-    <div class='login-link user-menu' role='button' tabindex='0' aria-haspopup='true' aria-expanded='false' aria-label='Menu utente'>
-    <div class='user-icon-bg'>
-      {$icon}
-    </div>
-    <div class='login-text'>{$username}</div>
-    <div class='user-menu-panel' aria-hidden='true'>
+    <details class='user-menu'>
+      <summary class='login-link' aria-label='Menu utente'>
+        <div class='user-icon-bg'>
+          {$icon}
+        </div>
+        <div class='login-text'>{$username}</div>
+      </summary>
+      <div class='user-menu-panel'>
       <a href='php/dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "
@@ -88,7 +90,7 @@ if (!SessionManager::isLoggedIn()) {
     $headerLoginHtml .= "
           <a href='php/logout.php'><span lang='en'>Logout</span></a>
         </div>
-    </div>";
+    </details>";
   }
 
 // Sostituzione dei placeholder nel template

--- a/js/main.js
+++ b/js/main.js
@@ -28,40 +28,6 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
-
-  const userMenus = document.querySelectorAll('.user-menu');
-  if (userMenus.length) {
-    userMenus.forEach((menu) => {
-      const panel = menu.querySelector('.user-menu-panel');
-      if (!panel) return;
-
-      menu.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const isOpen = panel.classList.toggle('open');
-        menu.setAttribute('aria-expanded', isOpen);
-        panel.setAttribute('aria-hidden', !isOpen);
-      });
-
-      menu.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          menu.click();
-        }
-      });
-    });
-
-    document.addEventListener('click', () => {
-      userMenus.forEach((menu) => {
-        const panel = menu.querySelector('.user-menu-panel');
-        if (panel && panel.classList.contains('open')) {
-          panel.classList.remove('open');
-          menu.setAttribute('aria-expanded', 'false');
-          panel.setAttribute('aria-hidden', 'true');
-        }
-      });
-    });
-  }
-
   const commentForm = document.getElementById('comment-form');
   if (commentForm) {
     commentForm.addEventListener('submit', async (e) => {

--- a/php/404.php
+++ b/php/404.php
@@ -36,11 +36,19 @@ if (!SessionManager::isLoggedIn()) {
     $username = $_SESSION['username'];
     $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
     $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
-    $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'><div class='user-icon-bg'>{$icon}</div><span class='login-text'>{$username}</span><div class='user-menu-panel' aria-hidden='true'><a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
+    $headerLoginHtml = "<details class='user-menu'>\n".
+                       "<summary class='login-link' aria-label='Menu utente'>\n".
+                       "<div class='user-icon-bg'>{$icon}</div>\n".
+                       "<span class='login-text'>{$username}</span>\n".
+                       "</summary>\n".
+                       "<div class='user-menu-panel'>\n".
+                       "<a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "<a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>";
     }
-    $headerLoginHtml .= "<a href='logout.php'><span lang='en'>Logout</span></a></div></div>";
+    $headerLoginHtml .= "<a href='logout.php'><span lang='en'>Logout</span></a>\n".
+                       "</div>\n".
+                       "</details>";
 }
 $header = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $header);
 

--- a/php/classifiche.php
+++ b/php/classifiche.php
@@ -66,12 +66,14 @@ if (!SessionManager::isLoggedIn()) {
     $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
 
     $headerLoginHtml = "
-    <div class='login-link user-menu' role='button' tabindex='0' aria-haspopup='true' aria-expanded='false' aria-label='Menu utente'>
-    <div class='user-icon-bg'>
-      {$icon}
-    </div>
-    <span class='login-text'>{$username}</span>
-    <div class='user-menu-panel' aria-hidden='true'>
+    <details class='user-menu'>
+      <summary class='login-link' aria-label='Menu utente'>
+        <div class='user-icon-bg'>
+          {$icon}
+        </div>
+        <span class='login-text'>{$username}</span>
+      </summary>
+      <div class='user-menu-panel'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "
@@ -80,7 +82,7 @@ if (!SessionManager::isLoggedIn()) {
     $headerLoginHtml .= "
           <a href='logout.php'><span lang='en'>Logout</span></a>
         </div>
-    </div>";
+    </details>";
 }
 // Sostituzione dei placeholder nel template
 $DOM = str_replace("<!--LOGIN_PLACEHOLDER-->", $contenutoLogin, $DOM);

--- a/php/dashboard.php
+++ b/php/dashboard.php
@@ -67,12 +67,14 @@ $username = $_SESSION['username'];
 $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
 $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
   $headerLoginHtml = "
-    <div class='login-link user-menu' role='button' tabindex='0' aria-haspopup='true' aria-expanded='false' aria-label='Menu utente'>
-    <div class='user-icon-bg'>
-      {$icon}
-    </div>
-    <span class='login-text'>{$username}</span>
-    <div class='user-menu-panel' aria-hidden='true'>
+    <details class='user-menu'>
+      <summary class='login-link' aria-label='Menu utente'>
+        <div class='user-icon-bg'>
+          {$icon}
+        </div>
+        <span class='login-text'>{$username}</span>
+      </summary>
+      <div class='user-menu-panel'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
 
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
@@ -83,7 +85,7 @@ $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$us
   $headerLoginHtml .= "
           <a href='logout.php'><span lang='en'>Logout</span></a>
         </div>
-    </div>";
+    </details>";
 $DOM = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $DOM);
 
 $userData = $userManager->getUserById(SessionManager::getUserId());

--- a/php/gestione_recensioni.php
+++ b/php/gestione_recensioni.php
@@ -64,17 +64,19 @@ $username = $_SESSION['username'];
 
 $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
 $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
-$headerLoginHtml = " <div class='login-link user-menu' role='button' tabindex='0' aria-haspopup='true' aria-expanded='false' aria-label='Menu utente'>
-                        <div class='user-icon-bg'>
-                          {$icon}
-                        </div>
-                        <span class='login-text'>{$username}</span>
-                        <div class='user-menu-panel' aria-hidden='true'>
+$headerLoginHtml = " <details class='user-menu'>
+                        <summary class='login-link' aria-label='Menu utente'>
+                          <div class='user-icon-bg'>
+                            {$icon}
+                          </div>
+                          <span class='login-text'>{$username}</span>
+                        </summary>
+                        <div class='user-menu-panel'>
                           <a href='dashboard.php'><span lang='en'>Dashboard</span></a>
                           <a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>
                           <a href='logout.php'><span lang='en'>Logout</span></a>
                         </div>
-                      </div>";
+                      </details>";
 $DOM = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $DOM);
 
 $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;

--- a/php/recensione.php
+++ b/php/recensione.php
@@ -82,11 +82,19 @@ if (!SessionManager::isLoggedIn()) {
     $username = $_SESSION['username'];
     $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
     $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
-    $headerLoginHtml = "<div class='login-link user-menu' aria-label='Menu utente'><div class='user-icon-bg'>{$icon}</div><span class='login-text'>{$username}</span><div class='user-menu-panel' aria-hidden='true'><a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
+    $headerLoginHtml = "<details class='user-menu'>\n" .
+        "<summary class='login-link' aria-label='Menu utente'>\n" .
+        "  <div class='user-icon-bg'>{$icon}</div>\n" .
+        "  <span class='login-text'>{$username}</span>\n" .
+        "</summary>\n" .
+        "<div class='user-menu-panel'>\n" .
+        "  <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "<a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>";
     }
-    $headerLoginHtml .= "<a href='logout.php'><span lang='en'>Logout</span></a></div></div>";
+    $headerLoginHtml .= "<a href='logout.php'><span lang='en'>Logout</span></a>\n" .
+        "</div>\n" .
+        "</details>";
 }
 
 $template = str_replace("<!-- HEADER_PLACEHOLDER -->", $header, $template);

--- a/php/recensioni.php
+++ b/php/recensioni.php
@@ -70,12 +70,14 @@ if (!SessionManager::isLoggedIn()) {
   $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
 
     $headerLoginHtml = "
-    <div class='login-link user-menu' role='button' tabindex='0' aria-haspopup='true' aria-expanded='false' aria-label='Menu utente'>
-    <div class='user-icon-bg'>
-      {$icon}
-    </div>
-    <span class='login-text'>{$username}</span>
-    <div class='user-menu-panel' aria-hidden='true'>
+    <details class='user-menu'>
+      <summary class='login-link' aria-label='Menu utente'>
+        <div class='user-icon-bg'>
+          {$icon}
+        </div>
+        <span class='login-text'>{$username}</span>
+      </summary>
+      <div class='user-menu-panel'>
       <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "
@@ -84,7 +86,7 @@ if (!SessionManager::isLoggedIn()) {
     $headerLoginHtml .= "
           <a href='logout.php'><span lang='en'>Logout</span></a>
         </div>
-    </div>";
+    </details>";
   }
 
 // Sostituzione dei placeholder nel template

--- a/php/registrazione.php
+++ b/php/registrazione.php
@@ -146,19 +146,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $username = $_SESSION['username'];
         $profilePhoto = $_SESSION['user_data']['profile_photo'] ?? $_SESSION['profile_photo'] ?? '';
         $icon = $profilePhoto ? "<img src='../{$profilePhoto}' alt='Foto profilo di {$username}' class='user-avatar'>" : "<svg width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' id='user-icon'><path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'></path><circle cx='12' cy='7' r='4'></circle></svg>";
-        $headerLoginHtml = "<div class='login-link user-menu' role='button' tabindex='0' aria-haspopup='true' aria-expanded='false' aria-label='Menu utente'>\n" .
-            "  <div class='user-icon-bg'>\n" .
-            "    {$icon}\n" .
-            "  </div>\n" .
-            "  <span class='login-text'>{$username}</span>\n" .
-            "  <div class='user-menu-panel' aria-hidden='true'>\n" .
+        $headerLoginHtml = "<details class='user-menu'>\n" .
+            "  <summary class='login-link' aria-label='Menu utente'>\n" .
+            "    <div class='user-icon-bg'>\n" .
+            "      {$icon}\n" .
+            "    </div>\n" .
+            "    <span class='login-text'>{$username}</span>\n" .
+            "  </summary>\n" .
+            "  <div class='user-menu-panel'>\n" .
             "    <a href='dashboard.php'><span lang='en'>Dashboard</span></a>";
         if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
             $headerLoginHtml .= "<a href='gestione_recensioni.php'><span>Gestione recensioni</span></a>";
         }
         $headerLoginHtml .= "<a href='logout.php'><span lang='en'>Logout</span></a>\n" .
             "  </div>\n" .
-            "</div>";
+            "</details>";
     }
 
     $header = str_replace("<!-- HEADER_LOGIN_PLACEHOLDER -->", $headerLoginHtml, $header);


### PR DESCRIPTION
## Summary
- remove `no-js` body class and related script
- convert user menu to `<details>` element
- update CSS to show dropdown via `[open]`
- drop JS handlers for the user menu

## Testing
- `npx pa11y static/index.html` *(fails: needs package install)*

------
https://chatgpt.com/codex/tasks/task_b_686173f271f88321866db66adf016427