### PR TITLE
Fix admin menu span and panel width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -313,7 +313,8 @@ textarea:focus,
   background: var(--surface);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
-  width: 100%;
+  width: auto;
+  min-width: 12rem;
   z-index: 100;
   overflow: hidden;
   opacity: 0;

--- a/index.php
+++ b/index.php
@@ -85,7 +85,7 @@ if (!SessionManager::isLoggedIn()) {
       <a href='php/dashboard.php'><span lang='en'>Dashboard</span></a>";
     if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
         $headerLoginHtml .= "
-          <a href='php/gestione_recensioni.php'>Gestione recensioni</a>";
+          <a href='php/gestione_recensioni.php'><span>Gestione recensioni</span></a>";
     }
     $headerLoginHtml .= "
           <a href='php/logout.php'><span lang='en'>Logout</span></a>


### PR DESCRIPTION
## Summary
- ensure the admin menu item is wrapped in a `<span>`
- adjust `.user-menu-panel` width so links aren't flush against the edge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686180a6461883218224fe7474329485