### PR TITLE
Update dashboard navigation

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -19,17 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  document.querySelectorAll('.nav-link').forEach(link => {
-    link.addEventListener('click', e => {
-      e.preventDefault();
-      const section = link.dataset.section;
-      document.querySelectorAll('.content-section').forEach(s => s.classList.remove('active'));
-      document.getElementById(`${section}-section`)?.classList.add('active');
-      document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
-      link.closest('.nav-item')?.classList.add('active');
-      history.pushState({section}, '', `#${section}`);
-    });
-  });
 
   document.getElementById('editCommentModalClose')?.addEventListener('click', () => closeModal('editCommentModal'));
   document.getElementById('cancelEditCommentBtn')?.addEventListener('click', () => closeModal('editCommentModal'));

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -49,6 +49,7 @@
           <div class="profile-info-section">
             <form class="profile-form" id="profileForm" method="post" action="dashboard.php">
               <input type="hidden" name="action" value="profile">
+              <input type="hidden" name="page" value="profilo">
               <div class="profile-basic-info">
                 <div class="profile-header">
                   <div class="profile-name-section">
@@ -140,6 +141,7 @@
           <!-- Barra di ricerca -->
           <div class="search-container">
             <form class="search-box" method="get">
+              <input type="hidden" name="page" value="commenti">
               <i aria-hidden="true" class="fas fa-search"></i>
               <input type="text" id="commentSearch" name="search" placeholder="Cerca nei tuoi commenti...">
               <div class="filter-options">
@@ -183,6 +185,7 @@
       </div>
       <form class="modal-body" id="passwordForm" method="post" action="dashboard.php">
         <input type="hidden" name="action" value="password">
+        <input type="hidden" name="page" value="profilo">
         <div class="form-group">
           <label for="currentPassword"><span lang="en">Password</span> attuale*</label>
           <input type="password" id="currentPassword" name="currentPassword" required>
@@ -246,6 +249,7 @@
       </div>
       <form id="editCommentForm" class="modal-body" method="post" action="dashboard.php">
         <input type="hidden" name="action" value="edit_comment">
+        <input type="hidden" name="page" value="commenti">
         <input type="hidden" id="editCommentId" name="comment_id">
         <div class="form-group">
           <label for="editCommentRating">Valutazione*</label>


### PR DESCRIPTION
## Summary
- remove sidebar click handling in `dashboard.js`
- persist active dashboard page via hidden `page` inputs
- support rendering profile or comments server-side
- adjust pagination to use `p` parameter

## Testing
- `php` not available, so no tests run

------
https://chatgpt.com/codex/tasks/task_b_6861b81faccc83218cf846ea822c2f56